### PR TITLE
Sector 1 Name Changes

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1.json
+++ b/randovania/games/fusion/logic_database/Sector 1.json
@@ -139,35 +139,35 @@
             },
             "nodes": {}
         },
-        "Atmosphreic Stablizer Northwest": {
+        "Atmosphreic Stabilizer Northwest": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_1"
             },
             "nodes": {}
         },
-        "Atmospheric Stablizer Northeast": {
+        "Atmospheric Stabilizer Northeast": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_2"
             },
             "nodes": {}
         },
-        "Atmospheric Stablizer Southwest": {
+        "Atmospheric Stabilizer Southwest": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_3"
             },
             "nodes": {}
         },
-        "Atmospheric Stablizer Southeast": {
+        "Atmospheric Stabilizer Southeast": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_4"
             },
             "nodes": {}
         },
-        "Atmospheric Stablizer Central": {
+        "Atmospheric Stabilizer Central": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_5"

--- a/randovania/games/fusion/logic_database/Sector 1.json
+++ b/randovania/games/fusion/logic_database/Sector 1.json
@@ -69,21 +69,21 @@
                 }
             }
         },
-        "Entrance Nav Room": {
+        "Entrance Navigation Room": {
             "default_node": null,
             "extra": {
                 "map_name": "generic_nav"
             },
             "nodes": {}
         },
-        "Entrance Save Station": {
+        "Entrance Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "generic_save"
             },
             "nodes": {}
         },
-        "Entrance Recharge Station": {
+        "Entrance Recharge Room": {
             "default_node": null,
             "extra": {
                 "map_name": "generic_recharge"
@@ -97,84 +97,84 @@
             },
             "nodes": {}
         },
-        "Lava Dip": {
+        "Lava Pool Annex": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_lava_dip"
             },
             "nodes": {}
         },
-        "Connection to Sector 3": {
+        "Connection to Sector 3 (PYR)": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_to_s3"
             },
             "nodes": {}
         },
-        "Lava Dive": {
+        "Lava Pool": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_lava_dive"
             },
             "nodes": {}
         },
-        "Shortcut Access": {
+        "Antechamber": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_shortcut_access"
             },
             "nodes": {}
         },
-        "Connection to Sector 2": {
+        "Connection to Sector 2 (TRO)": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_to_s2"
             },
             "nodes": {}
         },
-        "Blob Hallway": {
+        "Yameba Access": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_blob_hallway"
             },
             "nodes": {}
         },
-        "Ventilation Area 1": {
+        "Atmosphreic Stablizer Northwest": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_1"
             },
             "nodes": {}
         },
-        "Ventilation Area 2": {
+        "Atmospheric Stablizer Northeast": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_2"
             },
             "nodes": {}
         },
-        "Ventilation Area 3": {
+        "Atmospheric Stablizer Southwest": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_3"
             },
             "nodes": {}
         },
-        "Ventilation Area 4": {
+        "Atmospheric Stablizer Southeast": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_4"
             },
             "nodes": {}
         },
-        "Ventilation Area 5": {
+        "Atmospheric Stablizer Central": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_vent_area_5"
             },
             "nodes": {}
         },
-        "Halzyn Hallway": {
+        "Hornoad Road": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_halzyn_hallway"
@@ -223,7 +223,7 @@
             },
             "nodes": {}
         },
-        "Crab Storage": {
+        "Crab Cache": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_crab_storage"
@@ -258,7 +258,7 @@
             },
             "nodes": {}
         },
-        "Hidden Pond": {
+        "Watering Hole": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_hidden_pond"
@@ -272,14 +272,14 @@
             },
             "nodes": {}
         },
-        "Central Save": {
+        "Charge Core Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_central_save"
             },
             "nodes": {}
         },
-        "Charge Arena": {
+        "Charge Core Arena": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_charge_arena"
@@ -293,7 +293,7 @@
             },
             "nodes": {}
         },
-        "Crab Army": {
+        "Crab Rave": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_crab_army"
@@ -328,7 +328,7 @@
             },
             "nodes": {}
         },
-        "Acid Pool 1": {
+        "Tourian Entrance": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_acid_pool1"
@@ -342,35 +342,35 @@
             },
             "nodes": {}
         },
-        "Ridley Checkpoint": {
+        "Tourain Central Checkpoint": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_ridley_checkpoint"
             },
             "nodes": {}
         },
-        "Ridley Hub": {
+        "Tourain Central Hub": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_ridley_hub"
             },
             "nodes": {}
         },
-        "Ridley Save South": {
+        "Tourian Central Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_elevator"
             },
             "nodes": {}
         },
-        "PB room": {
+        "Animorphs Cache": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_pb_room"
             },
             "nodes": {}
         },
-        "Acid Pool 2": {
+        "Ripper Maze Access": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_acid_pool2"
@@ -384,28 +384,28 @@
             },
             "nodes": {}
         },
-        "Elevator to ": {
+        "Elevator to Restricted Zone": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_elevator_to"
             },
             "nodes": {}
         },
-        "Gold Pirates": {
+        "Golden Pirates": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_gold_pirates"
             },
             "nodes": {}
         },
-        "Ridley Hub 2": {
+        "Tourian Hub West": {
             "default_node": null,
             "extra": {
                 "map_name": "s1_ridley_hub2"
             },
             "nodes": {}
         },
-        "Ridley Save 2": {
+        "Tourian Western Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "generic_save_right"

--- a/randovania/games/fusion/logic_database/Sector 1.txt
+++ b/randovania/games/fusion/logic_database/Sector 1.txt
@@ -13,52 +13,52 @@ Extra - map_name: s1_elevator
       Trivial
 
 ----------------
-Entrance Nav Room
+Entrance Navigation Room
 Extra - map_name: generic_nav
 ----------------
-Entrance Save Station
+Entrance Save Room
 Extra - map_name: generic_save
 ----------------
-Entrance Recharge Station
+Entrance Recharge Room
 Extra - map_name: generic_recharge
 ----------------
 Entrance Hub
 Extra - map_name: s1_entrance_hub
 ----------------
-Lava Dip
+Lava Pool Annex
 Extra - map_name: s1_lava_dip
 ----------------
-Connection to Sector 3
+Connection to Sector 3 (PYR)
 Extra - map_name: s1_to_s3
 ----------------
-Lava Dive
+Lava Pool
 Extra - map_name: s1_lava_dive
 ----------------
-Shortcut Access
+Antechamber
 Extra - map_name: s1_shortcut_access
 ----------------
-Connection to Sector 2
+Connection to Sector 2 (TRO)
 Extra - map_name: s1_to_s2
 ----------------
-Blob Hallway
+Yameba Access
 Extra - map_name: s1_blob_hallway
 ----------------
-Ventilation Area 1
+Atmosphreic Stablizer Northwest
 Extra - map_name: s1_vent_area_1
 ----------------
-Ventilation Area 2
+Atmospheric Stablizer Northeast
 Extra - map_name: s1_vent_area_2
 ----------------
-Ventilation Area 3
+Atmospheric Stablizer Southwest
 Extra - map_name: s1_vent_area_3
 ----------------
-Ventilation Area 4
+Atmospheric Stablizer Southeast
 Extra - map_name: s1_vent_area_4
 ----------------
-Ventilation Area 5
+Atmospheric Stablizer Central
 Extra - map_name: s1_vent_area_5
 ----------------
-Halzyn Hallway
+Hornoad Road
 Extra - map_name: s1_halzyn_hallway
 ----------------
 Shaft North
@@ -79,7 +79,7 @@ Extra - map_name: s1_elevator
 Screw Shaft
 Extra - map_name: s1_screw_shaft
 ----------------
-Crab Storage
+Crab Cache
 Extra - map_name: s1_crab_storage
 ----------------
 Shaft South
@@ -94,22 +94,22 @@ Extra - map_name: s1_monkey_bars
 Charge Access
 Extra - map_name: s1_charge_access
 ----------------
-Hidden Pond
+Watering Hole
 Extra - map_name: s1_hidden_pond
 ----------------
 Hornoad Housing
 Extra - map_name: s1_hornoad_housing
 ----------------
-Central Save
+Charge Core Save Room
 Extra - map_name: s1_central_save
 ----------------
-Charge Arena
+Charge Core Arena
 Extra - map_name: s1_charge_arena
 ----------------
 Charge Exit
 Extra - map_name: s1_charge_exit
 ----------------
-Crab Army
+Crab Rave
 Extra - map_name: s1_crab_army
 ----------------
 Checkpoint 2
@@ -124,40 +124,40 @@ Extra - map_name: s1_east_save
 Wall Jump Challenge
 Extra - map_name: s1_wj_challenge
 ----------------
-Acid Pool 1
+Tourian Entrance
 Extra - map_name: s1_acid_pool1
 ----------------
 Ridley Shaft East
 Extra - map_name: s1_ridley_shaft_east
 ----------------
-Ridley Checkpoint
+Tourain Central Checkpoint
 Extra - map_name: s1_ridley_checkpoint
 ----------------
-Ridley Hub
+Tourain Central Hub
 Extra - map_name: s1_ridley_hub
 ----------------
-Ridley Save South
+Tourian Central Save Room
 Extra - map_name: s1_elevator
 ----------------
-PB room
+Animorphs Cache
 Extra - map_name: s1_pb_room
 ----------------
-Acid Pool 2
+Ripper Maze Access
 Extra - map_name: s1_acid_pool2
 ----------------
 Ripper Maze
 Extra - map_name: s1_ripper_maze
 ----------------
-Elevator to 
+Elevator to Restricted Zone
 Extra - map_name: s1_elevator_to
 ----------------
-Gold Pirates
+Golden Pirates
 Extra - map_name: s1_gold_pirates
 ----------------
-Ridley Hub 2
+Tourian Hub West
 Extra - map_name: s1_ridley_hub2
 ----------------
-Ridley Save 2
+Tourian Western Save Room
 Extra - map_name: generic_save_right
 ----------------
 Ridley Access

--- a/randovania/games/fusion/logic_database/Sector 1.txt
+++ b/randovania/games/fusion/logic_database/Sector 1.txt
@@ -43,19 +43,19 @@ Extra - map_name: s1_to_s2
 Yameba Access
 Extra - map_name: s1_blob_hallway
 ----------------
-Atmosphreic Stablizer Northwest
+Atmosphreic Stabilizer Northwest
 Extra - map_name: s1_vent_area_1
 ----------------
-Atmospheric Stablizer Northeast
+Atmospheric Stabilizer Northeast
 Extra - map_name: s1_vent_area_2
 ----------------
-Atmospheric Stablizer Southwest
+Atmospheric Stabilizer Southwest
 Extra - map_name: s1_vent_area_3
 ----------------
-Atmospheric Stablizer Southeast
+Atmospheric Stabilizer Southeast
 Extra - map_name: s1_vent_area_4
 ----------------
-Atmospheric Stablizer Central
+Atmospheric Stabilizer Central
 Extra - map_name: s1_vent_area_5
 ----------------
 Hornoad Road


### PR DESCRIPTION
Renamed all the room I could in sector 1, here are the major changes:
- Ventilation Areas 1-5 have been renamed to Atmospheric Stabilizers (NW, NE, etc.) akin to the original game
- Lower room areas are now referred to as Tourian instead of just Ridley's Area
- Save Stations are now referred to as Save Rooms akin to the original game (same applies for Navigation Recharge, etc.)
- (most) Rooms with checks in them have been renamed to reference Autumn Out of Habit's Fusion Maps that she made for the rando tourney a few years ago.
- Other Miscellaneous changes.