### PR TITLE
Main Deck and Sector 1 renames

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1092,7 +1092,7 @@
                 }
             }
         },
-        "Crew Loung Save Room": {
+        "Crew Lounge Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "Main Deck11",
@@ -1119,7 +1119,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Elevator to Central Hub",
-                        "node": "Door to Crew Loung Save Room"
+                        "node": "Door to Crew Lounge Save Room"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -2202,7 +2202,7 @@
                                 "items": []
                             }
                         },
-                        "Door to PB Geron Cache": {
+                        "Door to Habitation Storage": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -2302,7 +2302,7 @@
                         }
                     }
                 },
-                "Door to PB Geron Cache": {
+                "Door to Habitation Storage": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -2321,7 +2321,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "PB Geron Cache",
+                        "area": "Habitation Storage",
                         "node": "Door to Central Hub"
                     },
                     "default_dock_weakness": "L2 Hatch",
@@ -5884,7 +5884,7 @@
                     "override_default_lock_requirement": null,
                     "connections": {}
                 },
-                "Door to Reactor Scaffolding A": {
+                "Door to Silo Scaffolding A": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5903,7 +5903,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Reactor Scaffolding A",
+                        "area": "Silo Scaffolding A",
                         "node": "Door to Central Reactor Core (V)"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -6002,7 +6002,7 @@
                 }
             }
         },
-        "Reactor Scaffolding A": {
+        "Silo Scaffolding A": {
             "default_node": null,
             "extra": {
                 "map_name": "Main Deck50",
@@ -6026,7 +6026,7 @@
                     "pickup_index": 6,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Reactor Scaffolding B": {
+                        "Door to Silo Scaffolding B": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6055,7 +6055,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Central Reactor Core (V)",
-                        "node": "Door to Reactor Scaffolding A"
+                        "node": "Door to Silo Scaffolding A"
                     },
                     "default_dock_weakness": "Open Hatch",
                     "exclude_from_dock_rando": false,
@@ -6063,7 +6063,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Reactor Scaffolding B": {
+                        "Door to Silo Scaffolding B": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6072,7 +6072,7 @@
                         }
                     }
                 },
-                "Door to Reactor Scaffolding B": {
+                "Door to Silo Scaffolding B": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6091,8 +6091,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Reactor Scaffolding B",
-                        "node": "Door to Reactor Scaffolding A"
+                        "area": "Silo Scaffolding B",
+                        "node": "Door to Silo Scaffolding A"
                     },
                     "default_dock_weakness": "Open Hatch",
                     "exclude_from_dock_rando": false,
@@ -6118,7 +6118,7 @@
                 }
             }
         },
-        "Reactor Scaffolding B": {
+        "Silo Scaffolding B": {
             "default_node": null,
             "extra": {
                 "map_name": "Main Deck51",
@@ -6151,7 +6151,7 @@
                         }
                     }
                 },
-                "Door to Reactor Scaffolding A": {
+                "Door to Silo Scaffolding A": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6170,8 +6170,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Reactor Scaffolding A",
-                        "node": "Door to Reactor Scaffolding B"
+                        "area": "Silo Scaffolding A",
+                        "node": "Door to Silo Scaffolding B"
                     },
                     "default_dock_weakness": "Open Hatch",
                     "exclude_from_dock_rando": false,
@@ -6208,7 +6208,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Yakuza Arena",
-                        "node": "Door to Reactor Scaffolding B"
+                        "node": "Door to Silo Scaffolding B"
                     },
                     "default_dock_weakness": "Open Hatch",
                     "exclude_from_dock_rando": false,
@@ -6249,7 +6249,7 @@
                                 ]
                             }
                         },
-                        "Door to Reactor Scaffolding A": {
+                        "Door to Silo Scaffolding A": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -6690,7 +6690,7 @@
                 }
             }
         },
-        "PB Geron Cache": {
+        "Habitation Storage": {
             "default_node": null,
             "extra": {
                 "map_name": "Main Deck57",
@@ -6748,7 +6748,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Central Hub",
-                        "node": "Door to PB Geron Cache"
+                        "node": "Door to Habitation Storage"
                     },
                     "default_dock_weakness": "L2 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6880,7 +6880,7 @@
                     "override_default_lock_requirement": null,
                     "connections": {}
                 },
-                "Door to Reactor Scaffolding A": {
+                "Door to Silo Scaffolding A": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6899,7 +6899,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Reactor Scaffolding A",
+                        "area": "Silo Scaffolding A",
                         "node": "Door to Central Reactor Core (V)"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -8561,7 +8561,7 @@
                 "room_id": 76
             },
             "nodes": {
-                "Door to Crew Loung Save Room": {
+                "Door to Crew Lounge Save Room": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8580,7 +8580,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Crew Loung Save Room",
+                        "area": "Crew Lounge Save Room",
                         "node": "Door to Elevator to Central Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -8663,7 +8663,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Crew Loung Save Room": {
+                        "Door to Crew Lounge Save Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -9403,7 +9403,7 @@
                 "room_id": 86
             },
             "nodes": {
-                "Door to Reactor Scaffolding B": {
+                "Door to Silo Scaffolding B": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -9422,7 +9422,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Reactor Scaffolding B",
+                        "area": "Silo Scaffolding B",
                         "node": "Door to Yakuza Arena"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -9543,7 +9543,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Reactor Scaffolding B": {
+                        "Door to Silo Scaffolding B": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1092,7 +1092,7 @@
                 }
             }
         },
-        "Crew Lounge Save Room": {
+        "Crew Quaters Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "Main Deck11",
@@ -1119,7 +1119,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Elevator to Central Hub",
-                        "node": "Door to Crew Lounge Save Room"
+                        "node": "Door to Crew Quaters Save Room"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -8561,7 +8561,7 @@
                 "room_id": 76
             },
             "nodes": {
-                "Door to Crew Lounge Save Room": {
+                "Door to Crew Quaters Save Room": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8580,7 +8580,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Crew Lounge Save Room",
+                        "area": "Crew Quaters Save Room",
                         "node": "Door to Elevator to Central Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -8663,7 +8663,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Crew Lounge Save Room": {
+                        "Door to Crew Quaters Save Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -1092,7 +1092,7 @@
                 }
             }
         },
-        "Crew Quaters Save Room": {
+        "Crew Quarters Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "Main Deck11",
@@ -1119,7 +1119,7 @@
                     "default_connection": {
                         "region": "Main Deck",
                         "area": "Elevator to Central Hub",
-                        "node": "Door to Crew Quaters Save Room"
+                        "node": "Door to Crew Quarters Save Room"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -8561,7 +8561,7 @@
                 "room_id": 76
             },
             "nodes": {
-                "Door to Crew Quaters Save Room": {
+                "Door to Crew Quarters Save Room": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -8580,7 +8580,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Main Deck",
-                        "area": "Crew Quaters Save Room",
+                        "area": "Crew Quarters Save Room",
                         "node": "Door to Elevator to Central Hub"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -8663,7 +8663,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Crew Quaters Save Room": {
+                        "Door to Crew Quarters Save Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -226,12 +226,12 @@ Extra - room_id: 10
       Trivial
 
 ----------------
-Crew Loung Save Room
+Crew Lounge Save Room
 Extra - map_name: Main Deck11
 Extra - room_id: 11
 > Door to Elevator to Central Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Central Hub/Door to Crew Loung Save Room
+  * L0 Hatch to Elevator to Central Hub/Door to Crew Lounge Save Room
   * Extra - door_idx: 24
 
 ----------------
@@ -433,7 +433,7 @@ Extra - room_id: 18
       Trivial
   > Door to Main Deck Navigation Room West
       Trivial
-  > Door to PB Geron Cache
+  > Door to Habitation Storage
       Can Use Power Bombs
   > Other to Western Hub
       Can Use Any Bombs
@@ -452,9 +452,9 @@ Extra - room_id: 18
   > Door to Station Entrance
       Trivial
 
-> Door to PB Geron Cache; Heals? False
+> Door to Habitation Storage; Heals? False
   * Layers: default
-  * L2 Hatch to PB Geron Cache/Door to Central Hub
+  * L2 Hatch to Habitation Storage/Door to Central Hub
   * Extra - door_idx: 132
   > Door to Station Entrance
       Can Use Any Bombs
@@ -1168,9 +1168,9 @@ Extra - room_id: 49
   * Open Hatch to Silo Access/Door to Central Reactor Core (V)
   * Extra - door_idx: 112
 
-> Door to Reactor Scaffolding A; Heals? False
+> Door to Silo Scaffolding A; Heals? False
   * Layers: default
-  * Open Hatch to Reactor Scaffolding A/Door to Central Reactor Core (V)
+  * Open Hatch to Silo Scaffolding A/Door to Central Reactor Core (V)
   * Extra - door_idx: 113
 
 > Door to Reactor Checkpoint; Heals? False
@@ -1189,25 +1189,25 @@ Extra - room_id: 49
   * Extra - door_idx: 130
 
 ----------------
-Reactor Scaffolding A
+Silo Scaffolding A
 Extra - map_name: Main Deck50
 Extra - room_id: 50
 > Pickup (Energy Tank); Heals? False
   * Layers: default
   * Pickup 6; Category? Minor
-  > Door to Reactor Scaffolding B
+  > Door to Silo Scaffolding B
       Trivial
 
 > Door to Central Reactor Core (V); Heals? False
   * Layers: default
-  * Open Hatch to Central Reactor Core (V)/Door to Reactor Scaffolding A
+  * Open Hatch to Central Reactor Core (V)/Door to Silo Scaffolding A
   * Extra - door_idx: 114
-  > Door to Reactor Scaffolding B
+  > Door to Silo Scaffolding B
       Trivial
 
-> Door to Reactor Scaffolding B; Heals? False
+> Door to Silo Scaffolding B; Heals? False
   * Layers: default
-  * Open Hatch to Reactor Scaffolding B/Door to Reactor Scaffolding A
+  * Open Hatch to Silo Scaffolding B/Door to Silo Scaffolding A
   * Extra - door_idx: 115
   > Pickup (Energy Tank)
       Trivial
@@ -1215,7 +1215,7 @@ Extra - room_id: 50
       Trivial
 
 ----------------
-Reactor Scaffolding B
+Silo Scaffolding B
 Extra - map_name: Main Deck51
 Extra - room_id: 51
 > Pickup (Missile Tank); Heals? False
@@ -1224,23 +1224,23 @@ Extra - room_id: 51
   > Beside Pickup
       Trivial
 
-> Door to Reactor Scaffolding A; Heals? False
+> Door to Silo Scaffolding A; Heals? False
   * Layers: default
-  * Open Hatch to Reactor Scaffolding A/Door to Reactor Scaffolding B
+  * Open Hatch to Silo Scaffolding A/Door to Silo Scaffolding B
   * Extra - door_idx: 116
   > Beside Pickup
       Trivial
 
 > Door to Yakuza Arena; Heals? False
   * Layers: default
-  * Open Hatch to Yakuza Arena/Door to Reactor Scaffolding B
+  * Open Hatch to Yakuza Arena/Door to Silo Scaffolding B
   * Extra - door_idx: 117
 
 > Beside Pickup; Heals? False
   * Layers: default
   > Pickup (Missile Tank)
       Morph Ball
-  > Door to Reactor Scaffolding A
+  > Door to Silo Scaffolding A
       Can climb High Jump Wall
   > Door to Yakuza Arena
       All of the following:
@@ -1330,7 +1330,7 @@ Extra - room_id: 56
       Trivial
 
 ----------------
-PB Geron Cache
+Habitation Storage
 Extra - map_name: Main Deck57
 Extra - room_id: 57
 > Pickup (Power Bomb Tank); Heals? False
@@ -1341,7 +1341,7 @@ Extra - room_id: 57
 
 > Door to Central Hub; Heals? False
   * Layers: default
-  * L2 Hatch to Central Hub/Door to PB Geron Cache
+  * L2 Hatch to Central Hub/Door to Habitation Storage
   * Extra - door_idx: 131
   > Pickup (Power Bomb Tank)
       Morph Ball
@@ -1369,9 +1369,9 @@ Extra - room_id: 59
   * Tunnel to Silo Tunnel (C)/Other to Central Reactor Core
   * Extra - door_idx: 135
 
-> Door to Reactor Scaffolding A; Heals? False
+> Door to Silo Scaffolding A; Heals? False
   * Layers: default
-  * Open Hatch to Reactor Scaffolding A/Door to Central Reactor Core (V)
+  * Open Hatch to Silo Scaffolding A/Door to Central Reactor Core (V)
   * Extra - door_idx: 136
 
 > Door to Reactor Checkpoint; Heals? False
@@ -1715,9 +1715,9 @@ Extra - room_id: 75
 Elevator to Central Hub
 Extra - map_name: Main Deck76
 Extra - room_id: 76
-> Door to Crew Loung Save Room; Heals? False
+> Door to Crew Lounge Save Room; Heals? False
   * Layers: default
-  * L0 Hatch to Crew Loung Save Room/Door to Elevator to Central Hub
+  * L0 Hatch to Crew Lounge Save Room/Door to Elevator to Central Hub
   * Extra - door_idx: 100
   > Door to Habitation Deck Entrance
       Trivial
@@ -1733,7 +1733,7 @@ Extra - room_id: 76
   * Layers: default
   * L2 Hatch to Habitation Deck Entrance/Door to Elevator to Central Hub
   * Extra - door_idx: 179
-  > Door to Crew Loung Save Room
+  > Door to Crew Lounge Save Room
       Trivial
   > Other to Elevator to Habitation Deck
       Trivial
@@ -1893,9 +1893,9 @@ Extra - room_id: 85
 Yakuza Arena
 Extra - map_name: Main Deck86
 Extra - room_id: 86
-> Door to Reactor Scaffolding B; Heals? False
+> Door to Silo Scaffolding B; Heals? False
   * Layers: default
-  * Open Hatch to Reactor Scaffolding B/Door to Yakuza Arena
+  * Open Hatch to Silo Scaffolding B/Door to Yakuza Arena
   * Extra - door_idx: 3
   > Arena
       Trivial
@@ -1921,7 +1921,7 @@ Extra - room_id: 86
 
 > Arena; Heals? False
   * Layers: default
-  > Door to Reactor Scaffolding B
+  > Door to Silo Scaffolding B
       Space Jump and After Yakuza
   > Other to Auxiliary Power Station
       Space Jump

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -226,12 +226,12 @@ Extra - room_id: 10
       Trivial
 
 ----------------
-Crew Quaters Save Room
+Crew Quarters Save Room
 Extra - map_name: Main Deck11
 Extra - room_id: 11
 > Door to Elevator to Central Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Central Hub/Door to Crew Quaters Save Room
+  * L0 Hatch to Elevator to Central Hub/Door to Crew Quarters Save Room
   * Extra - door_idx: 24
 
 ----------------
@@ -1715,9 +1715,9 @@ Extra - room_id: 75
 Elevator to Central Hub
 Extra - map_name: Main Deck76
 Extra - room_id: 76
-> Door to Crew Quaters Save Room; Heals? False
+> Door to Crew Quarters Save Room; Heals? False
   * Layers: default
-  * L0 Hatch to Crew Quaters Save Room/Door to Elevator to Central Hub
+  * L0 Hatch to Crew Quarters Save Room/Door to Elevator to Central Hub
   * Extra - door_idx: 100
   > Door to Habitation Deck Entrance
       Trivial
@@ -1733,7 +1733,7 @@ Extra - room_id: 76
   * Layers: default
   * L2 Hatch to Habitation Deck Entrance/Door to Elevator to Central Hub
   * Extra - door_idx: 179
-  > Door to Crew Quaters Save Room
+  > Door to Crew Quarters Save Room
       Trivial
   > Other to Elevator to Habitation Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -226,12 +226,12 @@ Extra - room_id: 10
       Trivial
 
 ----------------
-Crew Lounge Save Room
+Crew Quaters Save Room
 Extra - map_name: Main Deck11
 Extra - room_id: 11
 > Door to Elevator to Central Hub; Heals? False
   * Layers: default
-  * L0 Hatch to Elevator to Central Hub/Door to Crew Lounge Save Room
+  * L0 Hatch to Elevator to Central Hub/Door to Crew Quaters Save Room
   * Extra - door_idx: 24
 
 ----------------
@@ -1715,9 +1715,9 @@ Extra - room_id: 75
 Elevator to Central Hub
 Extra - map_name: Main Deck76
 Extra - room_id: 76
-> Door to Crew Lounge Save Room; Heals? False
+> Door to Crew Quaters Save Room; Heals? False
   * Layers: default
-  * L0 Hatch to Crew Lounge Save Room/Door to Elevator to Central Hub
+  * L0 Hatch to Crew Quaters Save Room/Door to Elevator to Central Hub
   * Extra - door_idx: 100
   > Door to Habitation Deck Entrance
       Trivial
@@ -1733,7 +1733,7 @@ Extra - room_id: 76
   * Layers: default
   * L2 Hatch to Habitation Deck Entrance/Door to Elevator to Central Hub
   * Extra - door_idx: 179
-  > Door to Crew Lounge Save Room
+  > Door to Crew Quaters Save Room
       Trivial
   > Other to Elevator to Habitation Deck
       Trivial

--- a/randovania/games/fusion/logic_database/Sector 1.json
+++ b/randovania/games/fusion/logic_database/Sector 1.json
@@ -1248,7 +1248,7 @@
                 "room_id": 9
             },
             "nodes": {
-                "Door to Charge Core Exit": {
+                "Door to Charge Core Escape": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -1267,7 +1267,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Exit",
+                        "area": "Charge Core Escape",
                         "node": "Door to Atmospheric Stabilizer Central"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -1337,7 +1337,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Charge Core Exit": {
+                        "Door to Charge Core Escape": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -1419,7 +1419,7 @@
                 }
             }
         },
-        "Charge Core Exit": {
+        "Charge Core Escape": {
             "default_node": null,
             "extra": {
                 "map_name": "Sector 110",
@@ -1446,7 +1446,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Atmospheric Stabilizer Central",
-                        "node": "Door to Charge Core Exit"
+                        "node": "Door to Charge Core Escape"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -1509,7 +1509,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Charge Core Arena",
-                        "node": "Door to Charge Core Exit"
+                        "node": "Door to Charge Core Escape"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -1546,7 +1546,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Crab Rave",
-                        "node": "Other to Charge Core Exit"
+                        "node": "Other to Charge Core Escape"
                     },
                     "default_dock_weakness": "Tunnel",
                     "exclude_from_dock_rando": false,
@@ -3233,7 +3233,7 @@
                 "room_id": 21
             },
             "nodes": {
-                "Door to Golden Pirates": {
+                "Door to Gold Pirate Crossing": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3252,7 +3252,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Golden Pirates",
+                        "area": "Gold Pirate Crossing",
                         "node": "Door to Tourian Central Hub"
                     },
                     "default_dock_weakness": "Open Hatch",
@@ -3359,7 +3359,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Golden Pirates": {
+                        "Door to Gold Pirate Crossing": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3515,7 +3515,7 @@
                 }
             }
         },
-        "Golden Pirates": {
+        "Gold Pirate Crossing": {
             "default_node": null,
             "extra": {
                 "map_name": "Sector 122",
@@ -3542,7 +3542,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Tourian Central Hub",
-                        "node": "Door to Golden Pirates"
+                        "node": "Door to Gold Pirate Crossing"
                     },
                     "default_dock_weakness": "Open Hatch",
                     "exclude_from_dock_rando": false,
@@ -3610,7 +3610,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Tourian Hub West",
-                        "node": "Door to Golden Pirates"
+                        "node": "Door to Gold Pirate Crossing"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -3667,7 +3667,7 @@
                 "room_id": 23
             },
             "nodes": {
-                "Door to Golden Pirates": {
+                "Door to Gold Pirate Crossing": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3686,7 +3686,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Golden Pirates",
+                        "area": "Gold Pirate Crossing",
                         "node": "Door to Tourian Hub West"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -3709,7 +3709,7 @@
                                 "items": []
                             }
                         },
-                        "Door to Ridley Access": {
+                        "Door to Ridley Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3746,7 +3746,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Golden Pirates": {
+                        "Door to Gold Pirate Crossing": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3783,7 +3783,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Golden Pirates": {
+                        "Door to Gold Pirate Crossing": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3792,7 +3792,7 @@
                         }
                     }
                 },
-                "Door to Ridley Access": {
+                "Door to Ridley Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -3811,7 +3811,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Ridley Access",
+                        "area": "Ridley Arena Access",
                         "node": "Door to Tourian Hub West"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -3820,7 +3820,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Golden Pirates": {
+                        "Door to Gold Pirate Crossing": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -3912,7 +3912,7 @@
                 }
             }
         },
-        "Ridley Access": {
+        "Ridley Arena Access": {
             "default_node": null,
             "extra": {
                 "map_name": "Sector 126",
@@ -3939,7 +3939,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Tourian Hub West",
-                        "node": "Door to Ridley Access"
+                        "node": "Door to Ridley Arena Access"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -3973,7 +3973,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Ridley Arena",
-                        "node": "Door to Ridley Access"
+                        "node": "Door to Ridley Arena Access"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -3999,7 +3999,7 @@
                 "room_id": 27
             },
             "nodes": {
-                "Door to Ridley Access": {
+                "Door to Ridley Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4018,7 +4018,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Ridley Access",
+                        "area": "Ridley Arena Access",
                         "node": "Door to Ridley Arena"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -4114,7 +4114,7 @@
                     "pickup_index": 104,
                     "location_category": "major",
                     "connections": {
-                        "Door to Ridley Access": {
+                        "Door to Ridley Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -4806,7 +4806,7 @@
                         }
                     }
                 },
-                "Door to Monkey Bars": {
+                "Door to Sciser Playground": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -4825,7 +4825,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Monkey Bars",
+                        "area": "Sciser Playground",
                         "node": "Door to Short Shaft"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -4881,7 +4881,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Monkey Bars": {
+                        "Door to Sciser Playground": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5250,14 +5250,14 @@
                 }
             }
         },
-        "Charge Core Access": {
+        "Charge Core Arena Access": {
             "default_node": null,
             "extra": {
                 "map_name": "Sector 137",
                 "room_id": 37
             },
             "nodes": {
-                "Door to Monkey Bars": {
+                "Door to Sciser Playground": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5276,8 +5276,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Monkey Bars",
-                        "node": "Door to Charge Core Access"
+                        "area": "Sciser Playground",
+                        "node": "Door to Charge Core Arena Access"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5316,7 +5316,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Hornoad Housing",
-                        "node": "Door to Charge Core Access"
+                        "node": "Door to Charge Core Arena Access"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5362,7 +5362,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Charge Core Arena",
-                        "node": "Door to Charge Core Access"
+                        "node": "Door to Charge Core Arena Access"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5399,7 +5399,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Watering Hole",
-                        "node": "Other to Charge Core Access"
+                        "node": "Other to Charge Core Arena Access"
                     },
                     "default_dock_weakness": "Open Passage",
                     "exclude_from_dock_rando": false,
@@ -5415,14 +5415,14 @@
                 }
             }
         },
-        "Monkey Bars": {
+        "Sciser Playground": {
             "default_node": null,
             "extra": {
                 "map_name": "Sector 138",
                 "room_id": 38
             },
             "nodes": {
-                "Door to Charge Core Access": {
+                "Door to Charge Core Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5441,8 +5441,8 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Access",
-                        "node": "Door to Monkey Bars"
+                        "area": "Charge Core Arena Access",
+                        "node": "Door to Sciser Playground"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5489,7 +5489,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Short Shaft",
-                        "node": "Door to Monkey Bars"
+                        "node": "Door to Sciser Playground"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -5497,7 +5497,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Charge Core Access": {
+                        "Door to Charge Core Arena Access": {
                             "type": "or",
                             "data": {
                                 "comment": null,
@@ -5738,7 +5738,7 @@
                     "pickup_index": 19,
                     "location_category": "minor",
                     "connections": {
-                        "Door to Charge Core Access": {
+                        "Door to Charge Core Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5747,7 +5747,7 @@
                         }
                     }
                 },
-                "Door to Charge Core Access": {
+                "Door to Charge Core Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5766,7 +5766,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Access",
+                        "area": "Charge Core Arena Access",
                         "node": "Door to Charge Core Arena"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -5792,7 +5792,7 @@
                                 ]
                             }
                         },
-                        "Door to Charge Core Exit": {
+                        "Door to Charge Core Escape": {
                             "type": "resource",
                             "data": {
                                 "type": "events",
@@ -5820,7 +5820,7 @@
                         }
                     }
                 },
-                "Door to Charge Core Exit": {
+                "Door to Charge Core Escape": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -5839,7 +5839,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Exit",
+                        "area": "Charge Core Escape",
                         "node": "Door to Charge Core Arena"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -5848,7 +5848,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Charge Core Access": {
+                        "Door to Charge Core Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5897,7 +5897,7 @@
                     "extra": {},
                     "valid_starting_location": false,
                     "connections": {
-                        "Door to Charge Core Access": {
+                        "Door to Charge Core Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5991,7 +5991,7 @@
                 }
             }
         },
-        "Central Save Station": {
+        "Central Save Room": {
             "default_node": null,
             "extra": {
                 "map_name": "Sector 142",
@@ -6018,7 +6018,7 @@
                     "default_connection": {
                         "region": "Sector 1",
                         "area": "Hornoad Housing",
-                        "node": "Door to Central Save Station"
+                        "node": "Door to Central Save Room"
                     },
                     "default_dock_weakness": "L0 Hatch",
                     "exclude_from_dock_rando": false,
@@ -6053,7 +6053,7 @@
                     "pickup_index": 20,
                     "location_category": "minor",
                     "connections": {
-                        "Other to Charge Core Exit": {
+                        "Other to Charge Core Escape": {
                             "type": "resource",
                             "data": {
                                 "type": "items",
@@ -6064,7 +6064,7 @@
                         }
                     }
                 },
-                "Other to Charge Core Exit": {
+                "Other to Charge Core Escape": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6083,7 +6083,7 @@
                     "dock_type": "Other",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Exit",
+                        "area": "Charge Core Escape",
                         "node": "Other to Crab Rave"
                     },
                     "default_dock_weakness": "Tunnel",
@@ -6267,7 +6267,7 @@
                 "room_id": 46
             },
             "nodes": {
-                "Door to Central Save Station": {
+                "Door to Central Save Room": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6286,7 +6286,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Central Save Station",
+                        "area": "Central Save Room",
                         "node": "Door to Hornoad Housing"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -6295,7 +6295,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Charge Core Access": {
+                        "Door to Charge Core Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6304,7 +6304,7 @@
                         }
                     }
                 },
-                "Door to Charge Core Access": {
+                "Door to Charge Core Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6323,7 +6323,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Access",
+                        "area": "Charge Core Arena Access",
                         "node": "Door to Hornoad Housing"
                     },
                     "default_dock_weakness": "L0 Hatch",
@@ -6332,7 +6332,7 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Central Save Station": {
+                        "Door to Central Save Room": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6367,7 +6367,7 @@
                     "pickup_index": 22,
                     "location_category": "minor",
                     "connections": {
-                        "Other to Charge Core Access": {
+                        "Other to Charge Core Arena Access": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -6376,7 +6376,7 @@
                         }
                     }
                 },
-                "Other to Charge Core Access": {
+                "Other to Charge Core Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -6395,7 +6395,7 @@
                     "dock_type": "Other",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Charge Core Access",
+                        "area": "Charge Core Arena Access",
                         "node": "Other to Watering Hole"
                     },
                     "default_dock_weakness": "Open Passage",
@@ -7017,7 +7017,7 @@
                 "room_id": 53
             },
             "nodes": {
-                "Door to Ridley Access": {
+                "Door to Ridley Arena Access": {
                     "node_type": "dock",
                     "heal": false,
                     "coordinates": {
@@ -7036,7 +7036,7 @@
                     "dock_type": "Door",
                     "default_connection": {
                         "region": "Sector 1",
-                        "area": "Ridley Access",
+                        "area": "Ridley Arena Access",
                         "node": "Door to Ridley Arena"
                     },
                     "default_dock_weakness": "L0 Hatch",

--- a/randovania/games/fusion/logic_database/Sector 1.txt
+++ b/randovania/games/fusion/logic_database/Sector 1.txt
@@ -240,9 +240,9 @@ Extra - room_id: 8
 Atmospheric Stabilizer Central
 Extra - map_name: Sector 19
 Extra - room_id: 9
-> Door to Charge Core Exit; Heals? False
+> Door to Charge Core Escape; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Exit/Door to Atmospheric Stabilizer Central
+  * L0 Hatch to Charge Core Escape/Door to Atmospheric Stabilizer Central
   * Extra - door_idx: 23
   > Room Center
       Trivial
@@ -256,7 +256,7 @@ Extra - room_id: 9
 
 > Room Center; Heals? False
   * Layers: default
-  > Door to Charge Core Exit
+  > Door to Charge Core Escape
       After Stabilizer 5 Online
   > Door to Checkpoint
       After Stabilizer 5 Online
@@ -270,12 +270,12 @@ Extra - room_id: 9
       Trivial
 
 ----------------
-Charge Core Exit
+Charge Core Escape
 Extra - map_name: Sector 110
 Extra - room_id: 10
 > Door to Atmospheric Stabilizer Central; Heals? False
   * Layers: default
-  * L0 Hatch to Atmospheric Stabilizer Central/Door to Charge Core Exit
+  * L0 Hatch to Atmospheric Stabilizer Central/Door to Charge Core Escape
   * Extra - door_idx: 24
   > Door to Charge Core Arena
       Trivial
@@ -284,14 +284,14 @@ Extra - room_id: 10
 
 > Door to Charge Core Arena; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Arena/Door to Charge Core Exit
+  * L0 Hatch to Charge Core Arena/Door to Charge Core Escape
   * Extra - door_idx: 84
   > Door to Atmospheric Stabilizer Central
       Trivial
 
 > Other to Crab Rave; Heals? False
   * Layers: default
-  * Tunnel to Crab Rave/Other to Charge Core Exit
+  * Tunnel to Crab Rave/Other to Charge Core Escape
   * Extra - door_idx: 92
   > Door to Atmospheric Stabilizer Central
       Trivial
@@ -572,9 +572,9 @@ Extra - room_id: 20
 Tourian Central Hub
 Extra - map_name: Sector 121
 Extra - room_id: 21
-> Door to Golden Pirates; Heals? False
+> Door to Gold Pirate Crossing; Heals? False
   * Layers: default
-  * Open Hatch to Golden Pirates/Door to Tourian Central Hub
+  * Open Hatch to Gold Pirate Crossing/Door to Tourian Central Hub
   * Extra - door_idx: 45
   > Door to Ripper Maze Access
       Can Use Any Bombs
@@ -590,7 +590,7 @@ Extra - room_id: 21
   * Layers: default
   * L0 Hatch to Ripper Maze Access/Door to Tourian Central Hub
   * Extra - door_idx: 47
-  > Door to Golden Pirates
+  > Door to Gold Pirate Crossing
       All of the following:
           Can Use Any Bombs
           High Jump or Space Jump
@@ -616,12 +616,12 @@ Extra - room_id: 21
       Trivial
 
 ----------------
-Golden Pirates
+Gold Pirate Crossing
 Extra - map_name: Sector 122
 Extra - room_id: 22
 > Door to Tourian Central Hub; Heals? False
   * Layers: default
-  * Open Hatch to Tourian Central Hub/Door to Golden Pirates
+  * Open Hatch to Tourian Central Hub/Door to Gold Pirate Crossing
   * Extra - door_idx: 48
   > Door to Tourian Hub West
       All of the following:
@@ -630,7 +630,7 @@ Extra - room_id: 22
 
 > Door to Tourian Hub West; Heals? False
   * Layers: default
-  * L0 Hatch to Tourian Hub West/Door to Golden Pirates
+  * L0 Hatch to Tourian Hub West/Door to Gold Pirate Crossing
   * Extra - door_idx: 49
   > Door to Tourian Central Hub
       All of the following:
@@ -641,36 +641,36 @@ Extra - room_id: 22
 Tourian Hub West
 Extra - map_name: Sector 123
 Extra - room_id: 23
-> Door to Golden Pirates; Heals? False
+> Door to Gold Pirate Crossing; Heals? False
   * Layers: default
-  * L0 Hatch to Golden Pirates/Door to Tourian Hub West
+  * L0 Hatch to Gold Pirate Crossing/Door to Tourian Hub West
   * Extra - door_idx: 50
   > Door to Tourian Save Room West
       Trivial
   > Door to Genesis Habitation
       Trivial
-  > Door to Ridley Access
+  > Door to Ridley Arena Access
       Trivial
 
 > Door to Tourian Save Room West; Heals? False
   * Layers: default
   * L0 Hatch to Tourian Save Room West/Door to Tourian Hub West
   * Extra - door_idx: 51
-  > Door to Golden Pirates
+  > Door to Gold Pirate Crossing
       Trivial
 
 > Door to Genesis Habitation; Heals? False
   * Layers: default
   * L0 Hatch to Genesis Habitation/Door to Tourian Hub West
   * Extra - door_idx: 52
-  > Door to Golden Pirates
+  > Door to Gold Pirate Crossing
       Trivial
 
-> Door to Ridley Access; Heals? False
+> Door to Ridley Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Ridley Access/Door to Tourian Hub West
+  * L0 Hatch to Ridley Arena Access/Door to Tourian Hub West
   * Extra - door_idx: 53
-  > Door to Golden Pirates
+  > Door to Gold Pirate Crossing
       Can climb High Jump Wall
 
 ----------------
@@ -692,19 +692,19 @@ Extra - room_id: 25
   * Extra - door_idx: 55
 
 ----------------
-Ridley Access
+Ridley Arena Access
 Extra - map_name: Sector 126
 Extra - room_id: 26
 > Door to Tourian Hub West; Heals? False
   * Layers: default
-  * L0 Hatch to Tourian Hub West/Door to Ridley Access
+  * L0 Hatch to Tourian Hub West/Door to Ridley Arena Access
   * Extra - door_idx: 56
   > Door to Ridley Arena
       Can Kill Eye Door
 
 > Door to Ridley Arena; Heals? False
   * Layers: default
-  * L0 Hatch to Ridley Arena/Door to Ridley Access
+  * L0 Hatch to Ridley Arena/Door to Ridley Arena Access
   * Extra - door_idx: 57
   > Door to Tourian Hub West
       Trivial
@@ -713,9 +713,9 @@ Extra - room_id: 26
 Ridley Arena
 Extra - map_name: Sector 127
 Extra - room_id: 27
-> Door to Ridley Access; Heals? False
+> Door to Ridley Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Ridley Access/Door to Ridley Arena
+  * L0 Hatch to Ridley Arena Access/Door to Ridley Arena
   * Extra - door_idx: 58
   > Neo-Ridley
       All of the following:
@@ -731,7 +731,7 @@ Extra - room_id: 27
 > Pickup (Screw Attack); Heals? False
   * Layers: default
   * Pickup 104; Category? Major
-  > Door to Ridley Access
+  > Door to Ridley Arena Access
       Space Jump and After Neo-Ridley
 
 ----------------
@@ -865,9 +865,9 @@ Extra - room_id: 33
   > Door to Shaft North
       Trivial
 
-> Door to Monkey Bars; Heals? False
+> Door to Sciser Playground; Heals? False
   * Layers: default
-  * L0 Hatch to Monkey Bars/Door to Short Shaft
+  * L0 Hatch to Sciser Playground/Door to Short Shaft
   * Extra - door_idx: 70
   > Door to South Shaft
       Wave Beam
@@ -876,7 +876,7 @@ Extra - room_id: 33
   * Layers: default
   * L0 Hatch to South Shaft/Door to Short Shaft
   * Extra - door_idx: 71
-  > Door to Monkey Bars
+  > Door to Sciser Playground
       Trivial
 
 ----------------
@@ -938,19 +938,19 @@ Extra - room_id: 36
           Space Jump or Damage Runs (Intermediate)
 
 ----------------
-Charge Core Access
+Charge Core Arena Access
 Extra - map_name: Sector 137
 Extra - room_id: 37
-> Door to Monkey Bars; Heals? False
+> Door to Sciser Playground; Heals? False
   * Layers: default
-  * L0 Hatch to Monkey Bars/Door to Charge Core Access
+  * L0 Hatch to Sciser Playground/Door to Charge Core Arena Access
   * Extra - door_idx: 25
   > Door to Hornoad Housing
       Morph Ball
 
 > Door to Hornoad Housing; Heals? False
   * Layers: default
-  * L0 Hatch to Hornoad Housing/Door to Charge Core Access
+  * L0 Hatch to Hornoad Housing/Door to Charge Core Arena Access
   * Extra - door_idx: 77
   > Door to Charge Core Arena
       Can Kill Eye Door
@@ -959,34 +959,34 @@ Extra - room_id: 37
 
 > Door to Charge Core Arena; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Arena/Door to Charge Core Access
+  * L0 Hatch to Charge Core Arena/Door to Charge Core Arena Access
   * Extra - door_idx: 83
   > Door to Hornoad Housing
       Trivial
 
 > Other to Watering Hole; Heals? False
   * Layers: default
-  * Open Passage to Watering Hole/Other to Charge Core Access
+  * Open Passage to Watering Hole/Other to Charge Core Arena Access
   * Extra - door_idx: 100
   > Door to Hornoad Housing
       Can Use Any Bombs
 
 ----------------
-Monkey Bars
+Sciser Playground
 Extra - map_name: Sector 138
 Extra - room_id: 38
-> Door to Charge Core Access; Heals? False
+> Door to Charge Core Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Access/Door to Monkey Bars
+  * L0 Hatch to Charge Core Arena Access/Door to Sciser Playground
   * Extra - door_idx: 79
   > Door to Short Shaft
       Morph Ball
 
 > Door to Short Shaft; Heals? False
   * Layers: default
-  * L0 Hatch to Short Shaft/Door to Monkey Bars
+  * L0 Hatch to Short Shaft/Door to Sciser Playground
   * Extra - door_idx: 80
-  > Door to Charge Core Access
+  > Door to Charge Core Arena Access
       Morph Ball
 
 ----------------
@@ -1031,25 +1031,25 @@ Extra - room_id: 40
 > Pickup (Energy Tank); Heals? False
   * Layers: default
   * Pickup 19; Category? Minor
-  > Door to Charge Core Access
+  > Door to Charge Core Arena Access
       Trivial
 
-> Door to Charge Core Access; Heals? False
+> Door to Charge Core Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Access/Door to Charge Core Arena
+  * L0 Hatch to Charge Core Arena Access/Door to Charge Core Arena
   * Extra - door_idx: 82
   > Pickup (Energy Tank)
       Speed Booster
-  > Door to Charge Core Exit
+  > Door to Charge Core Escape
       After Charge Core-X
   > Event - Charge Core-X
       Missiles
 
-> Door to Charge Core Exit; Heals? False
+> Door to Charge Core Escape; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Exit/Door to Charge Core Arena
+  * L0 Hatch to Charge Core Escape/Door to Charge Core Arena
   * Extra - door_idx: 85
-  > Door to Charge Core Access
+  > Door to Charge Core Arena Access
       Trivial
 
 > Event - Charge Core-X; Heals? False
@@ -1060,7 +1060,7 @@ Extra - room_id: 40
 
 > Pickup (Charge Beam); Heals? False
   * Layers: default
-  > Door to Charge Core Access
+  > Door to Charge Core Arena Access
       Trivial
 
 ----------------
@@ -1082,12 +1082,12 @@ Extra - room_id: 41
       Trivial
 
 ----------------
-Central Save Station
+Central Save Room
 Extra - map_name: Sector 142
 Extra - room_id: 42
 > Door to Hornoad Housing; Heals? False
   * Layers: default
-  * L0 Hatch to Hornoad Housing/Door to Central Save Station
+  * L0 Hatch to Hornoad Housing/Door to Central Save Room
   * Extra - door_idx: 91
 
 ----------------
@@ -1097,12 +1097,12 @@ Extra - room_id: 43
 > Pickup (Missile Tank); Heals? False
   * Layers: default
   * Pickup 20; Category? Minor
-  > Other to Charge Core Exit
+  > Other to Charge Core Escape
       Morph Ball
 
-> Other to Charge Core Exit; Heals? False
+> Other to Charge Core Escape; Heals? False
   * Layers: default
-  * Tunnel to Charge Core Exit/Other to Crab Rave
+  * Tunnel to Charge Core Escape/Other to Crab Rave
   * Extra - door_idx: 93
   > Pickup (Missile Tank)
       Morph Ball
@@ -1146,18 +1146,18 @@ Extra - room_id: 45
 Hornoad Housing
 Extra - map_name: Sector 146
 Extra - room_id: 46
-> Door to Central Save Station; Heals? False
+> Door to Central Save Room; Heals? False
   * Layers: default
-  * L0 Hatch to Central Save Station/Door to Hornoad Housing
+  * L0 Hatch to Central Save Room/Door to Hornoad Housing
   * Extra - door_idx: 98
-  > Door to Charge Core Access
+  > Door to Charge Core Arena Access
       Trivial
 
-> Door to Charge Core Access; Heals? False
+> Door to Charge Core Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Charge Core Access/Door to Hornoad Housing
+  * L0 Hatch to Charge Core Arena Access/Door to Hornoad Housing
   * Extra - door_idx: 99
-  > Door to Central Save Station
+  > Door to Central Save Room
       Trivial
 
 ----------------
@@ -1167,12 +1167,12 @@ Extra - room_id: 47
 > Pickup (Hidden Power Bomb Tank); Heals? False
   * Layers: default
   * Pickup 22; Category? Minor
-  > Other to Charge Core Access
+  > Other to Charge Core Arena Access
       Trivial
 
-> Other to Charge Core Access; Heals? False
+> Other to Charge Core Arena Access; Heals? False
   * Layers: default
-  * Open Passage to Charge Core Access/Other to Watering Hole
+  * Open Passage to Charge Core Arena Access/Other to Watering Hole
   * Extra - door_idx: 101
   > Pickup (Hidden Power Bomb Tank)
       All of the following:
@@ -1284,8 +1284,8 @@ Extra - room_id: 52
 unused
 Extra - map_name: Sector 153
 Extra - room_id: 53
-> Door to Ridley Access; Heals? False
+> Door to Ridley Arena Access; Heals? False
   * Layers: default
-  * L0 Hatch to Ridley Access/Door to Ridley Arena
+  * L0 Hatch to Ridley Arena Access/Door to Ridley Arena
   * Extra - door_idx: 114
 

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -216,8 +216,8 @@
                 "long_name": "Reactor Control",
                 "extra": {}
             },
-            "Stablilizer1": {
-                "long_name": "Stablilizer 1 Online",
+            "Stabilizer1": {
+                "long_name": "Stabilizer 1 Online",
                 "extra": {}
             },
             "Stabilizer2": {
@@ -234,10 +234,6 @@
             },
             "Stabilizer5": {
                 "long_name": "Stabilizer 5 Online",
-                "extra": {}
-            },
-            "Stabilizer1": {
-                "long_name": "Stabilizer 1 Online",
                 "extra": {}
             },
             "Ridley": {


### PR DESCRIPTION
Reactor Scaffolding A & B are now referenced as Silo Scaffolding in tune with Silo Access, Silo Save Room and Silo Tunnel
Monkey Bars is now Sciser Playground
Golden Pirates is now Gold Pirate Crossing
Added "Arena" to Ridley Access, and Charge Core Access
Charge Core Exit is now Charge Core Escape
PB Geron Cache is now Habitation Storage

Also Removed "Stablilizer1" event because I spelled it wrong lol