### PR TITLE
misc logic updates

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -6612,57 +6612,139 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Pickup (Energy Tank)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
-                                "comment": "TODO: this shinespark isnt trivial and ideally needs more items",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": "Pre-Fight",
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "SpeedBooster",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "ShinesparkTrick",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "SpeedBooster",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "template",
+                                        "data": "Can Kill Eye Door"
+                                    },
+                                    {
+                                        "type": "resource",
                                         "data": {
-                                            "comment": "After Core-X defeated",
+                                            "type": "misc",
+                                            "name": "DoorLockRando",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "misc",
+                                            "name": "EntranceRando",
+                                            "amount": 1,
+                                            "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "SpeedBooster",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "After Fight, No Hi-Jump - TODO: rebalance trick levels(?)",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "ChargeCore-X",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "events",
-                                                        "name": "ChargeCore-X",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "Pre-Fight, with Hi-Jump",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "HighJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "After Fight, Trickless",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "HighJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "ChargeCore-X",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Pre-Fight, no Hi-Jump",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "ShinesparkTrick",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -1152,12 +1152,17 @@ Extra - room_id: [40]
 > Arena; Heals? False
   * Layers: default
   > Pickup (Energy Tank)
-      Any of the following:
-          # TODO: this shinespark isnt trivial and ideally needs more items
-          # Pre-Fight
-          Speed Booster and Shinespark Tricks (Beginner)
-          # After Core-X defeated
-          Speed Booster and After Charge Core-X
+      All of the following:
+          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando and Can Kill Eye Door
+          Any of the following:
+              # After Fight, No Hi-Jump - TODO: rebalance trick levels(?)
+              After Charge Core-X and Shinespark Tricks (Beginner)
+              # Pre-Fight, with Hi-Jump
+              High Jump and Shinespark Tricks (Beginner)
+              # After Fight, Trickless
+              High Jump and After Charge Core-X
+              # Pre-Fight, no Hi-Jump
+              Shinespark Tricks (Intermediate)
   > Door to Charge Core Arena Access
       After Charge Core-X
   > Door to Charge Core Escape

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -1228,6 +1228,15 @@
                                                 {
                                                     "type": "template",
                                                     "data": "Can climb High Jump Wall"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
                                                 }
                                             ]
                                         }
@@ -1242,7 +1251,23 @@
                                 "items": [
                                     {
                                         "type": "template",
-                                        "data": "Can Use Any Bombs"
+                                        "data": "Can Use Bombs"
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Springball"
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -1285,16 +1310,62 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ScrewAttack",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "WallJump",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -5326,6 +5397,32 @@
                                             "amount": 4,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -5437,6 +5534,32 @@
                                             "name": "Combat",
                                             "amount": 3,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "ShinesparkTrick",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -233,16 +233,22 @@ Extra - room_id: [9]
   > Pickup (Missile Tank)
       All of the following:
           Morph Ball
-          Can Activate Pillar or Can climb High Jump Wall
+          Wall Jump (Beginner) or Can Activate Pillar or Can climb High Jump Wall
   > Door to Maintenance Annex
-      Can Use Any Bombs
+      Any of the following:
+          Can Use Bombs
+          Can Use Power Bombs and Can Use Springball
 
 > Door to Maintenance Annex; Heals? False
   * Layers: default
   * L0 Hatch to Maintenance Annex/Door to Zoro Zig-Zag
   * Extra - door_idx: (21,)
   > Door to Data Hub
-      Space Jump and Can Use Any Bombs
+      All of the following:
+          Any of the following:
+              Can Use Power Bombs
+              Screw Attack and Can Use Bombs
+          Space Jump or Wall Jump (Intermediate)
 
 ----------------
 Cultivation Station
@@ -968,7 +974,9 @@ Extra - room_id: [33]
   * L0 Hatch to Entrance Hub/Door to Kago Room
   * Extra - door_idx: (73,)
   > Beside missile tank
-      High Jump or Space Jump or Movement (Expert) or Can Freeze Enemies
+      Any of the following:
+          High Jump or Space Jump or Movement (Expert) or Can Freeze Enemies
+          Speed Booster and Shinespark Tricks (Beginner)
 
 > Door to Connection to Sector 1 (SRX); Heals? False
   * Layers: default
@@ -982,7 +990,9 @@ Extra - room_id: [33]
   > Pickup (Missile Tank)
       Trivial
   > Door to Entrance Hub
-      High Jump or Space Jump or Combat (Advanced) or Can Freeze Enemies
+      Any of the following:
+          High Jump or Space Jump or Combat (Advanced) or Can Freeze Enemies
+          Speed Booster and Shinespark Tricks (Beginner)
   > Door to Connection to Sector 1 (SRX)
       Screw Attack
 

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -685,7 +685,7 @@
                         "Pickup (Hidden Missile Tank)": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: cant you also freeze the sidehopper?",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "and",
@@ -716,6 +716,41 @@
                                     {
                                         "type": "template",
                                         "data": "Can climb High Jump Wall"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "WallJump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "events",
+                                                        "name": "Level2Locks",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "StandOnFrozenEnemies",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -4086,15 +4121,6 @@
                                         "data": {
                                             "comment": null,
                                             "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "HighJump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
                                                 {
                                                     "type": "resource",
                                                     "data": {

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -131,9 +131,9 @@ Extra - room_id: [3]
   * Layers: default
   > Pickup (Hidden Missile Tank)
       Any of the following:
-          # TODO: cant you also freeze the sidehopper?
-          Can climb High Jump Wall
+          Wall Jump (Beginner) or Can climb High Jump Wall
           Speed Booster and Shinespark Tricks (Beginner)
+          After Level 2 Locks and Stand On Frozen Enemies (Beginner)
   > Door to Entrance Hub
       Speed Booster
   > Door to Level 2 Security Room
@@ -732,9 +732,7 @@ Extra - room_id: [23, 18]
   * L0 Hatch to B.O.X. Access/Door to B.O.X. Arena
   * Extra - door_idx: (46, 36)
   > Other to Deserted Runway
-      Any of the following:
-          Space Jump
-          High Jump and After B.O.X.
+      Space Jump or After B.O.X.
   > Event - B.O.X.
       All of the following:
           Charge Beam or Missiles


### PR DESCRIPTION
Updated connections in various places:
zoro zigzag now is possible to climb back up the room
charge core shinespark now accounts for a multitude of situations
killing the kago in kago rooom is now logical with a shinespark
S3 Security Access, has alternative ways to reach the item
removed highjump req for box arena to leave