### PR TITLE
Nettori and Spitter Speedway fixes

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -6252,6 +6252,10 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "template",
+                                        "data": "Can Bounce in Ball"
                                     }
                                 ]
                             }

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1153,7 +1153,7 @@ Extra - room_id: [47]
   * Extra - door_idx: (107,)
   > Pickup (Hidden Power Bomb Tank)
       All of the following:
-          Can Use Power Bombs
+          Can Bounce in Ball and Can Use Power Bombs
           Wall Jump (Beginner) or Can climb High Jump Wall
 
 > to Sub-Zero Containment; Heals? False

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -3893,6 +3893,32 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "Avoid Samus Eaters",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "HighJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
@@ -3903,8 +3929,8 @@
                     "node_type": "pickup",
                     "heal": false,
                     "coordinates": {
-                        "x": 291.77,
-                        "y": 316.98,
+                        "x": 377.96433470507543,
+                        "y": 167.74759945130313,
                         "z": 0.0
                     },
                     "description": "",

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -666,6 +666,8 @@ Extra - room_id: [22, 51]
           Missiles or Super Missiles
           # Health Requirements
           Combat (Beginner) or Normal Damage ≥ 100
+          # Avoid Samus Eaters
+          High Jump or Combat (Intermediate)
 
 > Pickup (Plasma Beam); Heals? False
   * Layers: default


### PR DESCRIPTION
Nettori now requires High jump or combat intermediate to account for the samus eaters in the arena
Added Can Bounce in Ball for spitter speedway