### PR TITLE
Sector 4 Trickless logic review with notes on some tricks

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 4 AQA.json
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.json
@@ -1065,7 +1065,7 @@
                         "Right Side": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "If strictly on right side, space or wall jump required",
                                 "items": [
                                     {
                                         "type": "or",
@@ -1506,16 +1506,7 @@
                                                         "items": [
                                                             {
                                                                 "type": "template",
-                                                                "data": "Can Use Bombs"
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "PowerBombs",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
+                                                                "data": "Can Use Power Bombs"
                                                             }
                                                         ]
                                                     }
@@ -2478,7 +2469,7 @@
                         "Door to Breeding Tank": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: Add the whacky WJs",
+                                "comment": "Space Jump or Wall Jumping is also required (very difficult wall jump without gravity, but it is possible)",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -2624,23 +2615,6 @@
                                 "comment": null,
                                 "items": []
                             }
-                        },
-                        "Other to Aquarium Storage": {
-                            "type": "or",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "GravitySuit",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    }
-                                ]
-                            }
                         }
                     }
                 },
@@ -2698,7 +2672,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "High Jump works if you freeze an enemy, but a wall jump is still required after that",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -2958,7 +2932,7 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Springball not required for tunnel access but inputs are tight",
                                             "items": [
                                                 {
                                                     "type": "template",
@@ -3116,10 +3090,12 @@
                             }
                         },
                         "Other to Cargo Hold to Sector 5 (ARC)": {
-                            "type": "and",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": []
+                                "type": "items",
+                                "name": "MorphBall",
+                                "amount": 1,
+                                "negate": false
                             }
                         },
                         "Door to Aquarium Save Room West": {
@@ -3445,7 +3421,7 @@
                         "Door to Aquarium Hub Access": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "High Jump would still require freezing enemies",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -4083,12 +4059,80 @@
                                             "comment": "To get over Powamp",
                                             "items": [
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Freeze Enemies"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "GravitySuit",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Springball"
+                                                            }
+                                                        ]
+                                                    }
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Bounce in Ball"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "To freeze the powamp",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "DiffusionMissiles",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "WaveBeam",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "IceBeam",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -4165,34 +4209,6 @@
                                             "amount": 1,
                                             "negate": false
                                         }
-                                    },
-                                    {
-                                        "type": "and",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can Freeze Enemies"
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Bombs"
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Springball"
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
                                     }
                                 ]
                             }
@@ -4238,8 +4254,37 @@
                                                     "data": "Can Freeze Enemies"
                                                 },
                                                 {
-                                                    "type": "template",
-                                                    "data": "Can Bounce in Ball"
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "GravitySuit",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Springball"
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -5152,7 +5197,7 @@
                     "pickup_index": 64,
                     "location_category": "minor",
                     "connections": {
-                        "Other to Aquarium Shaft West": {
+                        "Small Nook": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5390,15 +5435,8 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Pickup (Power Bomb Tank)": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": []
-                            }
-                        },
-                        "Room Center": {
-                            "type": "and",
+                        "Small Nook": {
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -5406,16 +5444,7 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "GravitySuit",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
+                                            "name": "MorphBall",
                                             "amount": 1,
                                             "negate": false
                                         }
@@ -5525,7 +5554,107 @@
                                 "items": []
                             }
                         },
+                        "Small Nook": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "GravitySuit",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "ScrewAttack",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Small Nook": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 920.0,
+                        "y": 102.0,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
+                        "Pickup (Power Bomb Tank)": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
                         "Other to Aquarium Shaft West": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Springball"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "Room Center": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -5635,7 +5764,7 @@
                         "Other to Security Bypass": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Two block height in tube prevents screw attack from working here",
                                 "items": [
                                     {
                                         "type": "template",
@@ -5727,7 +5856,7 @@
                         "Pickup (Power Bomb Tank)": {
                             "type": "and",
                             "data": {
-                                "comment": null,
+                                "comment": "Hi Jump not required, with area effect/wall cutting weapon (wave, diffusion, power bomb) or bombs",
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7110,6 +7239,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -7195,8 +7333,8 @@
                     "node_type": "generic",
                     "heal": false,
                     "coordinates": {
-                        "x": 120.8414181872126,
-                        "y": 188.9618750927162,
+                        "x": 137.0,
+                        "y": 188.0,
                         "z": 0.0
                     },
                     "description": "",
@@ -7235,8 +7373,42 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Use Bombs"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Bombs"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Bombs assumes the water was lowered, grav required otherwise",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "events",
+                                                                    "name": "LowerWaterLevel",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "template",
@@ -7730,6 +7902,15 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -8044,7 +8225,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Power Bombs also work on Super Missile Geron",
                                             "items": [
                                                 {
                                                     "type": "resource",
@@ -8475,20 +8656,12 @@
                                         }
                                     },
                                     {
-                                        "type": "and",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "HeatRuns",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "tricks",
+                                            "name": "HeatRuns",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -8860,7 +9033,7 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "Wall Jump is also sufficent here",
                                             "items": [
                                                 {
                                                     "type": "and",
@@ -9106,15 +9279,49 @@
                                     {
                                         "type": "or",
                                         "data": {
-                                            "comment": null,
+                                            "comment": "To hurt the golden scisers",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "ChargeBeam",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "ChargeBeam",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "or",
+                                                                "data": {
+                                                                    "comment": null,
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "Missiles",
+                                                                                "amount": 2,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "items",
+                                                                                "name": "WaveBeam",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 },
                                                 {
@@ -9139,26 +9346,6 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "and",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Power Bombs"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -9176,12 +9363,42 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
+                                                        "name": "Missiles",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": "To hurt the scisers in the enclosed area",
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
                                                         "name": "WaveBeam",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -9309,8 +9526,37 @@
                                         "data": "Can Use Any Bombs"
                                     },
                                     {
-                                        "type": "template",
-                                        "data": "Can Bounce in Ball"
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Springball"
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Bombs"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }

--- a/randovania/games/fusion/logic_database/Sector 4 AQA.txt
+++ b/randovania/games/fusion/logic_database/Sector 4 AQA.txt
@@ -156,6 +156,7 @@ Extra - room_id: [3]
               Ice Beam and Wave Beam
   > Right Side
       All of the following:
+          # If strictly on right side, space or wall jump required
           Gravity Suit
           Any of the following:
               After Water Level Lowered
@@ -223,7 +224,7 @@ Extra - room_id: [6]
   * Extra - door_idx: (13,)
   > Pickup (Hidden Power Bomb Tank)
       All of the following:
-          Power Bombs and Can Use Bombs
+          Can Use Power Bombs
           Any of the following:
               After Water Level Lowered
               Gravity Suit and Damage Runs (Beginner)
@@ -380,7 +381,7 @@ Extra - room_id: [10]
   * L0 Hatch to Serris Arena/Door to Broken Bridge
   * Extra - door_idx: (64,)
   > Door to Breeding Tank
-      # TODO: Add the whacky WJs
+      # Space Jump or Wall Jumping is also required (very difficult wall jump without gravity, but it is possible)
       Gravity Suit and Space Jump
 
 ----------------
@@ -409,8 +410,6 @@ Extra - room_id: [12]
   * Extra - door_idx: (88,)
   > Door to Powamp Shaft
       Trivial
-  > Other to Aquarium Storage
-      Gravity Suit
 
 > Door to Powamp Shaft; Heals? False
   * Layers: default
@@ -421,6 +420,7 @@ Extra - room_id: [12]
   > Other to Aquarium Storage
       All of the following:
           Gravity Suit
+          # High Jump works if you freeze an enemy, but a wall jump is still required after that
           High Jump or Space Jump
 
 > Other to Aquarium Storage; Heals? False
@@ -475,6 +475,7 @@ Extra - room_id: [13]
   > Pickup (Hidden Missile Tank)
       Any of the following:
           Can Use Bombs
+          # Springball not required for tunnel access but inputs are tight
           Can Use Power Bombs and Can Use Springball
   > Pickup (Missile Tank)
       All of the following:
@@ -503,7 +504,7 @@ Extra - room_id: [14]
   > Door to Aquarium Tank
       Trivial
   > Other to Cargo Hold to Sector 5 (ARC)
-      Trivial
+      Morph Ball
   > Door to Aquarium Save Room West
       Trivial
 
@@ -570,6 +571,7 @@ Extra - room_id: [16]
   * Extra - door_idx: (36,)
   > Door to Aquarium Hub Access
       All of the following:
+          # High Jump would still require freezing enemies
           Gravity Suit
           Any of the following:
               Space Jump
@@ -664,8 +666,15 @@ Extra - room_id: [19]
       Any of the following:
           # To destroy Powamp
           Gravity Suit and Screw Attack
-          # To get over Powamp
-          Can Bounce in Ball and Can Freeze Enemies
+          All of the following:
+              # To get over Powamp
+              Any of the following:
+                  Can Use Springball
+                  Gravity Suit and Can Use Bombs
+              Any of the following:
+                  # To freeze the powamp
+                  Diffusion Missiles
+                  Ice Beam and Wave Beam
 
 > Door to Aquarium Save Room East; Heals? False
   * Layers: default
@@ -677,16 +686,16 @@ Extra - room_id: [19]
 > Room Center; Heals? False
   * Layers: default
   > Door to Aquarium Hub Access
-      Any of the following:
-          Morph Ball
-          All of the following:
-              Can Freeze Enemies
-              Can Use Bombs or Can Use Springball
+      Morph Ball
   > Door to Aquarium Speedway
       Gravity Suit and Screw Attack
   > Door to Drain Pipe
       Any of the following:
-          Can Bounce in Ball and Can Freeze Enemies
+          All of the following:
+              Can Freeze Enemies
+              Any of the following:
+                  Can Use Springball
+                  Gravity Suit and Can Use Bombs
           Gravity Suit and Screw Attack
   > Door to Aquarium Save Room East
       Trivial
@@ -819,7 +828,7 @@ Extra - room_id: [23]
   * Extra - room: 23
   * Extra - blockx: 57
   * Extra - blocky: 19
-  > Other to Aquarium Shaft West
+  > Small Nook
       Trivial
 
 > Door to Pump Control Access; Heals? False
@@ -848,10 +857,8 @@ Extra - room_id: [23]
   * Layers: default
   * Tunnel to Aquarium Shaft West/Other to Cargo Hold to Sector 5 (ARC)
   * Extra - door_idx: (78,)
-  > Pickup (Power Bomb Tank)
-      Trivial
-  > Room Center
-      Gravity Suit and Screw Attack
+  > Small Nook
+      Morph Ball
 
 > Room Center; Heals? False
   * Layers: default
@@ -863,7 +870,20 @@ Extra - room_id: [23]
           High Jump or Movement (Beginner)
   > Other to Flooded Airlock to Sector 4 (AQA)
       Trivial
+  > Small Nook
+      Gravity Suit and Screw Attack
+
+> Small Nook; Heals? False
+  * Layers: default
+  > Pickup (Power Bomb Tank)
+      Trivial
   > Other to Aquarium Shaft West
+      All of the following:
+          Morph Ball
+          Any of the following:
+              Can Use Springball
+              Gravity Suit and Can Use Bombs
+  > Room Center
       Gravity Suit and Screw Attack
 
 ----------------
@@ -887,6 +907,7 @@ Extra - room_id: [24]
   > Door to Aquarium Shaft West
       Trivial
   > Other to Security Bypass
+      # Two block height in tube prevents screw attack from working here
       Missiles and Can Use Any Bombs
 
 > Door to Aquarium Shaft West; Heals? False
@@ -902,6 +923,7 @@ Extra - room_id: [24]
   * Extra - door_idx: (80,)
   > Pickup (Power Bomb Tank)
       All of the following:
+          # Hi Jump not required, with area effect/wall cutting weapon (wave, diffusion, power bomb) or bombs
           Morph Ball
           Gravity Suit or High Jump
   > Door to Security Access
@@ -1147,7 +1169,7 @@ Extra - room_id: [33]
   * L1 Hatch to Pump Control Access/Door to Pump Control Unit
   * Extra - door_idx: (76,)
   > Pickup (Missile Tank)
-      Gravity Suit and Space Jump and Damage Runs (Beginner)
+      Gravity Suit and Morph Ball and Space Jump and Damage Runs (Beginner)
   > Behind Speed Blocks
       Speed Booster
 
@@ -1171,7 +1193,12 @@ Extra - room_id: [33]
   > Door to Pump Control Access
       Can Use Bombs or Can Use Springball
   > Behind Speed Blocks
-      Can Use Bombs or Can Use Springball
+      Any of the following:
+          Can Use Springball
+          All of the following:
+              Can Use Bombs
+              # Bombs assumes the water was lowered, grav required otherwise
+              Gravity Suit or After Water Level Lowered
 
 ----------------
 Security Bypass
@@ -1223,7 +1250,7 @@ Extra - room_id: [35]
   * Extra - door_idx: (56,)
   > Door to Owtch-Couch
       All of the following:
-          Missiles
+          Missiles and Morph Ball
           Any of the following:
               Movement (Beginner) and Can Freeze Enemies
               All of the following:
@@ -1275,6 +1302,7 @@ Extra - room_id: [36]
               After Water Level Lowered or Damage Runs (Intermediate)
               Gravity Suit and Damage Runs (Beginner)
           Any of the following:
+              # Power Bombs also work on Super Missile Geron
               Super Missiles or Wave Beam
               All of the following:
                   Gravity Suit
@@ -1380,6 +1408,7 @@ Extra - room_id: [38]
       All of the following:
           Gravity Suit and Morph Ball and Knowledge (Beginner)
           Any of the following:
+              # Wall Jump is also sufficent here
               Space Jump
               Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
 
@@ -1416,12 +1445,16 @@ Extra - room_id: [40]
   * Extra - door_idx: (101,)
   > Door to Sanctuary Cache
       All of the following:
+          Morph Ball
           Any of the following:
-              Charge Beam
-              Gravity Suit and Screw Attack
-          Any of the following:
-              Wave Beam
-              Missiles ≥ 2 and Can Use Power Bombs
+              # To hurt the golden scisers
+              Missiles ≥ 5
+              All of the following:
+                  Charge Beam
+                  Missiles ≥ 2 or Wave Beam
+              Gravity Suit and Missiles ≥ 2 and Screw Attack
+          # To hurt the scisers in the enclosed area
+          Wave Beam or Can Use Power Bombs
 
 > Door to Sanctuary Cache; Heals? False
   * Layers: default
@@ -1449,7 +1482,11 @@ Extra - room_id: [41]
   * L0 Hatch to Sciser Sanctuary/Door to Sanctuary Cache
   * Extra - door_idx: (103,)
   > Pickup (Hidden Energy Tank)
-      Can Bounce in Ball and Can Use Any Bombs
+      All of the following:
+          Can Use Any Bombs
+          Any of the following:
+              Can Use Springball
+              Gravity Suit and Can Use Bombs
 
 ----------------
 Serris Arena


### PR DESCRIPTION
Added comments to several locations

Reservoir East: Door to Sciser Stall -> Pickup (Hidden Power Bomb Tank)
  * Changed template to "Can Use Power Bombs" 
  Template should cover all requirements here

Aquarium Speedway: Door to Aquarium Hub -> Other to Aquarium Storage
  * Removed a looping connection 
  Simplifing the pathing for the randomizer by avoiding a loop

Aquarium Shaft West: Door to Worst Room in the Game -> Other to Cargo Hold to Sector 5 (ARC)
  * Added Morph Ball requirement 
  Passage is 1 block tall

Aquarium Hub: Door to Drain Pipe -> Room Center
  * Requirements changed 
  Bomb jumping was not accounting for gravity suit requirement due to the area being underwater. Freeze enemies was not accounting for the fact that the powamp is blocked from direct missile hits, so diffusion would be required (without other tricks).

Aquarium Hub: Room Center -> Door to Aquarium Hub Access
  * Remove freezing enemies requirement 
  The path to the right and down is open

Aquarium Hub: Room Center -> Door to Drain Pipe
  * Added gravity suit requirement on bombs
  Area is underwater, bomb jumping doesn't work without gravity suit.

Cargo Hold to Sector 5 (ARC):
  * Added node "Small Nook"
  * Changed the routing logic 
  The item is collectable from both sides with different items.  From left, gravity + screw attack. From right, Morph Ball, and high jump to leave (among other options). This ensures that the pathing has the correct options.

Pump Control Unit: Door to Pump Control Access -> Pickup (Missile Tank)
  * Added Morph Ball requirement 
  Access from the right requires going through a 1 tile high gap

 Pump Control Unit: Next To Pickup -> Behind Speed Blocks
  * Added Gravity or Water Lowered to bomb jumping requirement 
  Bomb jump would be ineffective otherwise

Powamp Shaft: Door to Aquarium Speedway -> Door to Owtch-Couch
  * Added Morph Ball requirement 
  Going to or from this door requires traversing the 1 tile tall gap to the right.

Drain Pipe: Door to Aquarium Storage -> Door to Aquarium Hub
  * Removed a wrapping "and" 
  Was wrapping one item and had no comment

Sciser Sanctuary: Other to Security Access -> Door to Sancutary Cache
  * Corrected logic 
  Ensuring everything can be handled with the right requirements

Sanctuary Cache: Door to Sciser Sanctuary -> Pickup (Hidden Energy Tank)
  * Adding Gravity to bomb jump requirement 
  Underwater area