### PR TITLE
Fusion s3 non damage logic cleanup

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -1978,7 +1978,7 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Use Any Bombs"
+                                                    "data": "Can Activate Pillar"
                                                 },
                                                 {
                                                     "type": "or",

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -1964,32 +1964,91 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Pickup (Hidden Energy Tank)": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "and",
                                         "data": {
-                                            "comment": "TODO: space jump requires mid air morph if you have bombs. this whole block should probably get refacted a bit",
+                                            "comment": "Use Pillar to Morph Ball Jump and place a Bomb",
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Activate Pillar"
+                                                    "data": "Can Use Bombs"
                                                 },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Bomb Jump is harder",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Springball"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Pillar is hidden information, most players may not even know it exists unless you Power Bomb the room",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Knowledge",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Use Power Bombs"
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Alternate - Screw Attack and some extra Jump height (knowledge)",
+                                            "items": [
                                                 {
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "items",
-                                                        "name": "SpaceJump",
+                                                        "name": "ScrewAttack",
                                                         "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
-                                                    "type": "and",
+                                                    "type": "resource",
                                                     "data": {
-                                                        "comment": "TODO: how is this supposed to be done if you have screw?",
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
                                                         "items": [
                                                             {
                                                                 "type": "resource",
@@ -2003,8 +2062,8 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "WallJump",
+                                                                    "type": "items",
+                                                                    "name": "SpaceJump",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -2014,10 +2073,6 @@
                                                 }
                                             ]
                                         }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Break Single Bomb Blocks"
                                     }
                                 ]
                             }
@@ -3709,7 +3764,7 @@
                         "Door to Main Boiler Control Room": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: varia suit?",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
@@ -5150,25 +5205,8 @@
                                     {
                                         "type": "and",
                                         "data": {
-                                            "comment": "TODO: Heat dmg",
+                                            "comment": null,
                                             "items": [
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Heat DMG",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "VariaSuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
                                                 {
                                                     "type": "or",
                                                     "data": {

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -1978,46 +1978,37 @@
                                             "items": [
                                                 {
                                                     "type": "template",
-                                                    "data": "Can Use Bombs"
+                                                    "data": "Can Use Any Bombs"
                                                 },
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "Bomb Jump is harder",
+                                                        "comment": null,
                                                         "items": [
                                                             {
-                                                                "type": "resource",
+                                                                "type": "and",
                                                                 "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Movement",
-                                                                    "amount": 1,
-                                                                    "negate": false
+                                                                    "comment": "Bomb Jump is harder",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "Movement",
+                                                                                "amount": 1,
+                                                                                "negate": false
+                                                                            }
+                                                                        },
+                                                                        {
+                                                                            "type": "template",
+                                                                            "data": "Can Use Bombs"
+                                                                        }
+                                                                    ]
                                                                 }
                                                             },
                                                             {
                                                                 "type": "template",
                                                                 "data": "Can Use Springball"
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": "Pillar is hidden information, most players may not even know it exists unless you Power Bomb the room",
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "tricks",
-                                                                    "name": "Knowledge",
-                                                                    "amount": 2,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Use Power Bombs"
                                                             }
                                                         ]
                                                     }
@@ -2049,30 +2040,8 @@
                                                     }
                                                 },
                                                 {
-                                                    "type": "or",
-                                                    "data": {
-                                                        "comment": null,
-                                                        "items": [
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "HighJump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
-                                                                    "name": "SpaceJump",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
+                                                    "type": "template",
+                                                    "data": "Can climb High Jump Wall"
                                                 }
                                             ]
                                         }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -333,7 +333,7 @@ Extra - room_id: [8]
       Any of the following:
           All of the following:
               # Use Pillar to Morph Ball Jump and place a Bomb
-              Can Use Any Bombs
+              Can Activate Pillar
               Any of the following:
                   Can Use Springball
                   # Bomb Jump is harder

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -333,15 +333,13 @@ Extra - room_id: [8]
       Any of the following:
           All of the following:
               # Use Pillar to Morph Ball Jump and place a Bomb
-              Can Use Bombs
-              # Bomb Jump is harder
-              Movement (Beginner) or Can Use Springball
-              # Pillar is hidden information, most players may not even know it exists unless you Power Bomb the room
-              Knowledge (Intermediate) or Can Use Power Bombs
-          All of the following:
-              # Alternate - Screw Attack and some extra Jump height (knowledge)
-              Screw Attack and Knowledge (Beginner)
-              High Jump or Space Jump
+              Can Use Any Bombs
+              Any of the following:
+                  Can Use Springball
+                  # Bomb Jump is harder
+                  Movement (Beginner) and Can Use Bombs
+          # Alternate - Screw Attack and some extra Jump height (knowledge)
+          Screw Attack and Knowledge (Beginner) and Can climb High Jump Wall
   > Other to Entrance Hub
       Any of the following:
           Can Use Power Bombs

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -328,13 +328,18 @@ Extra - room_id: [8]
 > Below E-Tank; Heals? False
   * Layers: default
   > Pickup (Hidden Energy Tank)
-      All of the following:
-          Can Break Single Bomb Blocks
-          Any of the following:
-              # TODO: space jump requires mid air morph if you have bombs. this whole block should probably get refacted a bit
-              Space Jump or Can Activate Pillar
-              # TODO: how is this supposed to be done if you have screw?
-              High Jump and Wall Jump (Beginner)
+      Any of the following:
+          All of the following:
+              # Use Pillar to Morph Ball Jump and place a Bomb
+              Can Use Bombs
+              # Bomb Jump is harder
+              Movement (Beginner) or Can Use Springball
+              # Pillar is hidden information, most players may not even know it exists unless you Power Bomb the room
+              Knowledge (Intermediate) or Can Use Power Bombs
+          All of the following:
+              # Alternate - Screw Attack and some extra Jump height (knowledge)
+              Screw Attack and Knowledge (Beginner)
+              High Jump or Space Jump
   > Other to Entrance Hub
       Any of the following:
           Can Use Power Bombs
@@ -602,7 +607,6 @@ Extra - room_id: [17, 29]
   * L0 Hatch to Boiler Access/Door to Main Boiler
   * Extra - door_idx: (34, 72)
   > Door to Main Boiler Control Room
-      # TODO: varia suit?
       Can Kill Eye Door
 
 > Door to Main Boiler Control Room; Heals? False
@@ -823,14 +827,10 @@ Extra - room_id: [25]
           # Core-X Requirements
           Missiles
           Combat (Beginner) or 20 DMG Missiles
-          All of the following:
-              # TODO: Heat dmg
-              # Heat DMG
-              Varia Suit
-              Any of the following:
-                  # Normal DMG
-                  Combat (Intermediate) or Normal Damage ≥ 200
-                  Combat (Beginner) and Normal Damage ≥ 100
+          Any of the following:
+              # Normal DMG
+              Combat (Intermediate) or Normal Damage ≥ 200
+              Combat (Beginner) and Normal Damage ≥ 100
 
 > Event - Cooling Unit; Heals? False
   * Layers: default


### PR DESCRIPTION
Fix up the Alcove logic - the todo suggesting a mid air morph is ignoring the pillar that exists, and the current logic allow Screw Attack without Space Jump or High Jump, which isn't possible.*

Boiler Room and the Boss Room aren't heated rooms (the red tint is from the emergency alert effect) and don't need damage run requirements or Varia

\* (It _is_, but only by abusing the item disabling feature and performing a few frame-perfect inputs in sequence, which I don't think should be in logic)