### PR TITLE
S3: Adding in damage logic for straightforward sections

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -4103,12 +4103,29 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "HeatDamage",
-                                            "amount": 5,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -7294,7 +7311,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "damage",
-                                                        "name": "HeatDamage",
+                                                        "name": "LavaDamage",
                                                         "amount": 45,
                                                         "negate": false
                                                     }

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -3056,7 +3056,7 @@
                         "Door to Lava Reservoirs": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: Add damage reqs",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -3065,6 +3065,32 @@
                                             "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 15,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3116,7 +3142,7 @@
                         "Door to Pyrochamber Access": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: add damage reqs",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -3125,6 +3151,32 @@
                                             "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 10,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3165,7 +3217,7 @@
                         "Door to Lava Maze": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: add damage reqs",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -3174,6 +3226,32 @@
                                             "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 10,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3599,9 +3677,9 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Main Boiler": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
-                                "comment": "TODO: add damage reqs?",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -3610,6 +3688,32 @@
                                             "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Clean leap across",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 20,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -3648,10 +3752,36 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Pyrochamber": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
-                                "comment": "TODO: Add damage reqs?",
+                                "comment": null,
                                 "items": [
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": "Clean leap across",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 20,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    },
                                     {
                                         "type": "resource",
                                         "data": {
@@ -3893,6 +4023,32 @@
                                                         "amount": 1,
                                                         "negate": false
                                                     }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "HeatDamage",
+                                                                    "amount": 5,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }
@@ -3933,7 +4089,7 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Beside Lava": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -3943,6 +4099,15 @@
                                             "type": "items",
                                             "name": "VariaSuit",
                                             "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "damage",
+                                            "name": "HeatDamage",
+                                            "amount": 5,
                                             "negate": false
                                         }
                                     }
@@ -3996,26 +4161,69 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "GravitySuit",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Heat Run Logic",
+                                            "comment": "Heat Run logic (need Gravity to do Screw Attack in the lava)",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "VariaSuit",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "Gravity - Lava and Heat Damage",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "LavaDamage",
+                                                                    "amount": 110,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Varia and Gravity - No Damage",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "VariaSuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -4102,7 +4310,7 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Door to Processing Access (Lower)": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -4113,6 +4321,32 @@
                                             "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4130,6 +4364,32 @@
                                             "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 5,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -4150,26 +4410,69 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "GravitySuit",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
                                         "type": "or",
                                         "data": {
-                                            "comment": "Heat Run logic",
+                                            "comment": "Heat Run logic (need Gravity to do Screw Attack in the lava)",
                                             "items": [
                                                 {
-                                                    "type": "resource",
+                                                    "type": "and",
                                                     "data": {
-                                                        "type": "items",
-                                                        "name": "VariaSuit",
-                                                        "amount": 1,
-                                                        "negate": false
+                                                        "comment": "Gravity - Lava and Heat Damage",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "LavaDamage",
+                                                                    "amount": 110,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Varia and Gravity - No Damage",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "GravitySuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "VariaSuit",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -4225,6 +4528,32 @@
                                                         "name": "VariaSuit",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "HeatDamage",
+                                                                    "amount": 85,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -6868,7 +7197,7 @@
                     "location_category": "minor",
                     "connections": {
                         "Beside Pickup": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -6879,6 +7208,49 @@
                                             "name": "ScrewAttack",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "VariaSuit",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "HeatDamage",
+                                                                    "amount": 40,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -6909,14 +7281,50 @@
                     "location_category": "minor",
                     "connections": {
                         "Door to Sova Processing": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "VariaSuit",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 45,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Beside Pickup": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -6927,6 +7335,49 @@
                                             "name": "SpeedBooster",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "VariaSuit",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "HeatDamage",
+                                                                    "amount": 40,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -6967,7 +7418,7 @@
                         "Pickup (Power Bomb Tank in Shaft)": {
                             "type": "and",
                             "data": {
-                                "comment": "TODO: Heat DMG",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "resource",
@@ -7012,6 +7463,49 @@
                                             "name": "EntranceRando",
                                             "amount": 1,
                                             "negate": true
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "VariaSuit",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "LavaDamage",
+                                                                    "amount": 75,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]
@@ -7066,7 +7560,7 @@
                     "valid_starting_location": false,
                     "connections": {
                         "Pickup (Power Bomb Tank in Cave)": {
-                            "type": "or",
+                            "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
@@ -7078,15 +7572,94 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "VariaSuit",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "HeatRuns",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "HeatDamage",
+                                                                    "amount": 40,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     }
                                 ]
                             }
                         },
                         "Pickup (Power Bomb Tank in Shaft)": {
-                            "type": "and",
+                            "type": "or",
                             "data": {
                                 "comment": null,
-                                "items": []
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "VariaSuit",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 40,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         },
                         "Door to Chute Access": {
@@ -7098,9 +7671,35 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "items",
-                                            "name": "SpeedBooster",
+                                            "name": "VariaSuit",
                                             "amount": 1,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "HeatRuns",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "damage",
+                                                        "name": "HeatDamage",
+                                                        "amount": 30,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.json
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.json
@@ -4173,15 +4173,6 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "GravitySuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
                                                                     "type": "tricks",
                                                                     "name": "HeatRuns",
                                                                     "amount": 2,
@@ -4209,15 +4200,6 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "GravitySuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
                                                                     "name": "VariaSuit",
                                                                     "amount": 1,
                                                                     "negate": false
@@ -4227,6 +4209,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "GravitySuit",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -4422,15 +4413,6 @@
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
-                                                                    "type": "items",
-                                                                    "name": "GravitySuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
                                                                     "type": "tricks",
                                                                     "name": "HeatRuns",
                                                                     "amount": 2,
@@ -4458,15 +4440,6 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "GravitySuit",
-                                                                    "amount": 1,
-                                                                    "negate": false
-                                                                }
-                                                            },
-                                                            {
-                                                                "type": "resource",
-                                                                "data": {
-                                                                    "type": "items",
                                                                     "name": "VariaSuit",
                                                                     "amount": 1,
                                                                     "negate": false
@@ -4476,6 +4449,15 @@
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "GravitySuit",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -661,7 +661,9 @@ Extra - room_id: [19]
   * L0 Hatch to Processing Access/Door to Sova Processing (Upper)
   * Extra - door_idx: (75,)
   > Beside Lava
-      Varia Suit or Heat Damage ≥ 5
+      Any of the following:
+          Varia Suit
+          Damage Runs (Beginner) and Heat Damage ≥ 5
 
 > Door to Garbage Chute; Heals? False
   * Layers: default
@@ -1180,7 +1182,7 @@ Extra - room_id: [35]
   > Door to Sova Processing
       Any of the following:
           Varia Suit
-          Damage Runs (Intermediate) and Heat Damage ≥ 45
+          Damage Runs (Intermediate) and Lava Damage ≥ 45
   > Beside Pickup
       All of the following:
           Speed Booster

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -504,8 +504,9 @@ Extra - room_id: [12]
   * L0 Hatch to Sova Suite/Door to Lava Maze
   * Extra - door_idx: (25,)
   > Door to Lava Reservoirs
-      # TODO: Add damage reqs
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          Damage Runs (Intermediate) and Heat Damage ≥ 15
 
 ----------------
 Sova Suite
@@ -516,16 +517,18 @@ Extra - room_id: [13]
   * L0 Hatch to Lava Maze/Door to Sova Suite
   * Extra - door_idx: (26,)
   > Door to Pyrochamber Access
-      # TODO: add damage reqs
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          Damage Runs (Intermediate) and Heat Damage ≥ 10
 
 > Door to Pyrochamber Access; Heals? False
   * Layers: default
   * L0 Hatch to Pyrochamber Access/Door to Sova Suite
   * Extra - door_idx: (27,)
   > Door to Lava Maze
-      # TODO: add damage reqs
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          Damage Runs (Intermediate) and Heat Damage ≥ 10
 
 ----------------
 Pyrochamber Access
@@ -584,16 +587,20 @@ Extra - room_id: [16]
   * L0 Hatch to Pyrochamber/Door to Boiler Access
   * Extra - door_idx: (32,)
   > Door to Main Boiler
-      # TODO: add damage reqs?
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          # Clean leap across
+          Damage Runs (Intermediate) and Heat Damage ≥ 20
 
 > Door to Main Boiler; Heals? False
   * Layers: default
   * L0 Hatch to Main Boiler/Door to Boiler Access
   * Extra - door_idx: (33,)
   > Door to Pyrochamber
-      # TODO: Add damage reqs?
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          # Clean leap across
+          Damage Runs (Intermediate) and Heat Damage ≥ 20
 
 ----------------
 Main Boiler
@@ -643,14 +650,18 @@ Extra - room_id: [19]
   * L0 Hatch to Processing Access/Door to Sova Processing (Lower)
   * Extra - door_idx: (40,)
   > Beside Lava
-      Varia Suit and Wave Beam
+      All of the following:
+          Wave Beam
+          Any of the following:
+              Varia Suit
+              Damage Runs (Beginner) and Heat Damage ≥ 5
 
 > Door to Processing Access (Upper); Heals? False
   * Layers: default
   * L0 Hatch to Processing Access/Door to Sova Processing (Upper)
   * Extra - door_idx: (75,)
   > Beside Lava
-      Varia Suit
+      Varia Suit or Heat Damage ≥ 5
 
 > Door to Garbage Chute; Heals? False
   * Layers: default
@@ -658,9 +669,13 @@ Extra - room_id: [19]
   * Extra - door_idx: (78,)
   > Beside Lava
       All of the following:
-          Gravity Suit and Screw Attack
-          # Heat Run Logic
-          Varia Suit
+          Screw Attack
+          Any of the following:
+              # Heat Run logic (need Gravity to do Screw Attack in the lava)
+              # Gravity - Lava and Heat Damage
+              Gravity Suit and Damage Runs (Intermediate) and Lava Damage ≥ 110
+              # Varia and Gravity - No Damage
+              Gravity Suit and Varia Suit
 
 > Beside Pickups; Heals? False
   * Layers: default
@@ -674,18 +689,29 @@ Extra - room_id: [19]
 > Beside Lava; Heals? False
   * Layers: default
   > Door to Processing Access (Lower)
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          Damage Runs (Beginner) and Heat Damage ≥ 5
   > Door to Processing Access (Upper)
-      Varia Suit
+      Any of the following:
+          Varia Suit
+          Damage Runs (Beginner) and Heat Damage ≥ 5
   > Door to Garbage Chute
       All of the following:
-          Gravity Suit and Screw Attack
-          # Heat Run logic
-          Varia Suit
+          Screw Attack
+          Any of the following:
+              # Heat Run logic (need Gravity to do Screw Attack in the lava)
+              # Gravity - Lava and Heat Damage
+              Gravity Suit and Damage Runs (Intermediate) and Lava Damage ≥ 110
+              # Varia and Gravity - No Damage
+              Gravity Suit and Varia Suit
   > Beside Pickups
       All of the following:
-          Morph Ball and Varia Suit
+          Morph Ball
           Space Jump or Movement (Expert) or Can Freeze Enemies
+          Any of the following:
+              Varia Suit
+              Damage Runs (Intermediate) and Heat Damage ≥ 85
 
 ----------------
 Elevator to Main Deck
@@ -1138,7 +1164,11 @@ Extra - room_id: [35]
   * Extra - blockx: 4
   * Extra - blocky: 27
   > Beside Pickup
-      Screw Attack
+      All of the following:
+          Screw Attack
+          Any of the following:
+              Varia Suit
+              Damage Runs (Beginner) and Heat Damage ≥ 40
 
 > Pickup (Power Bomb Tank in Shaft); Heals? False
   * Layers: default
@@ -1148,17 +1178,26 @@ Extra - room_id: [35]
   * Extra - blockx: 15
   * Extra - blocky: 86
   > Door to Sova Processing
-      Trivial
+      Any of the following:
+          Varia Suit
+          Damage Runs (Intermediate) and Heat Damage ≥ 45
   > Beside Pickup
-      Speed Booster
+      All of the following:
+          Speed Booster
+          Any of the following:
+              Varia Suit
+              Damage Runs (Beginner) and Heat Damage ≥ 40
 
 > Door to Sova Processing; Heals? False
   * Layers: default
   * L0 Hatch to Sova Processing/Door to Garbage Chute
   * Extra - door_idx: (79,)
   > Pickup (Power Bomb Tank in Shaft)
-      # TODO: Heat DMG
-      Gravity Suit and Screw Attack and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+      All of the following:
+          Gravity Suit and Screw Attack and Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
+          Any of the following:
+              Varia Suit
+              Damage Runs (Intermediate) and Lava Damage ≥ 75
 
 > Door to Chute Access; Heals? False
   * Layers: default
@@ -1168,11 +1207,19 @@ Extra - room_id: [35]
 > Beside Pickup; Heals? False
   * Layers: default
   > Pickup (Power Bomb Tank in Cave)
-      Screw Attack
+      All of the following:
+          Screw Attack
+          Any of the following:
+              Varia Suit
+              Damage Runs (Beginner) and Heat Damage ≥ 40
   > Pickup (Power Bomb Tank in Shaft)
-      Trivial
+      Any of the following:
+          Varia Suit
+          Damage Runs (Beginner) and Heat Damage ≥ 40
   > Door to Chute Access
-      Speed Booster
+      Any of the following:
+          Varia Suit
+          Damage Runs (Beginner) and Heat Damage ≥ 30
 
 ----------------
 Chute Access

--- a/randovania/games/fusion/logic_database/Sector 3 PYR.txt
+++ b/randovania/games/fusion/logic_database/Sector 3 PYR.txt
@@ -669,13 +669,13 @@ Extra - room_id: [19]
   * Extra - door_idx: (78,)
   > Beside Lava
       All of the following:
-          Screw Attack
+          Gravity Suit and Screw Attack
           Any of the following:
               # Heat Run logic (need Gravity to do Screw Attack in the lava)
               # Gravity - Lava and Heat Damage
-              Gravity Suit and Damage Runs (Intermediate) and Lava Damage ≥ 110
+              Damage Runs (Intermediate) and Lava Damage ≥ 110
               # Varia and Gravity - No Damage
-              Gravity Suit and Varia Suit
+              Varia Suit
 
 > Beside Pickups; Heals? False
   * Layers: default
@@ -698,13 +698,13 @@ Extra - room_id: [19]
           Damage Runs (Beginner) and Heat Damage ≥ 5
   > Door to Garbage Chute
       All of the following:
-          Screw Attack
+          Gravity Suit and Screw Attack
           Any of the following:
               # Heat Run logic (need Gravity to do Screw Attack in the lava)
               # Gravity - Lava and Heat Damage
-              Gravity Suit and Damage Runs (Intermediate) and Lava Damage ≥ 110
+              Damage Runs (Intermediate) and Lava Damage ≥ 110
               # Varia and Gravity - No Damage
-              Gravity Suit and Varia Suit
+              Varia Suit
   > Beside Pickups
       All of the following:
           Morph Ball


### PR DESCRIPTION
Damage logic for the less complicated rooms that need it

Boiler Access
Garbage Chute
Lava Maze
Sova Processing
Sova Suite

All of this logic adds only one or two damage run options, since there aren't major obstacles for these runs