### PR TITLE
S1: Rework a few rooms to have better node layouts for more accurate logic

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -480,9 +480,18 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Atmospheric Stabilizer Northwest": {
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "S1MissileGeron",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Missile Geron": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: make this an event",
+                                "comment": null,
                                 "items": [
                                     {
                                         "type": "template",
@@ -550,15 +559,48 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Entrance Hub": {
-                            "type": "or",
+                            "type": "resource",
+                            "data": {
+                                "type": "events",
+                                "name": "S1MissileGeron",
+                                "amount": 1,
+                                "negate": false
+                            }
+                        },
+                        "Event - Missile Geron": {
+                            "type": "template",
+                            "data": "Can Kill Geron"
+                        }
+                    }
+                },
+                "Event - Missile Geron": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 660.39,
+                        "y": 130.98,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "S1MissileGeron",
+                    "connections": {
+                        "Door to Entrance Hub": {
+                            "type": "and",
                             "data": {
                                 "comment": null,
-                                "items": [
-                                    {
-                                        "type": "template",
-                                        "data": "Can Kill Geron"
-                                    }
-                                ]
+                                "items": []
+                            }
+                        },
+                        "Door to Atmospheric Stabilizer Northwest": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -1953,13 +1995,22 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "Missiles",
+                                            "type": "events",
+                                            "name": "S1MissileBlock",
                                             "amount": 1,
                                             "negate": false
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Event - Missile Block": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "Missiles",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -2037,7 +2088,60 @@
                             "type": "and",
                             "data": {
                                 "comment": null,
+                                "items": [
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "S1MissileBlock",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Event - Missile Block": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 87.32,
+                        "y": 296.44,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "S1MissileBlock",
+                    "connections": {
+                        "Door to Atmospheric Stabilizer Central": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
                                 "items": []
+                            }
+                        },
+                        "Other to Crab Rave": {
+                            "type": "resource",
+                            "data": {
+                                "type": "items",
+                                "name": "MorphBall",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -6196,26 +6300,9 @@
                     "pickup_index": 17,
                     "location_category": "major",
                     "connections": {
-                        "Door to Elevator to Restricted Zone": {
-                            "type": "and",
-                            "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Bounce in Ball"
-                                    }
-                                ]
-                            }
+                        "Top of Shaft": {
+                            "type": "template",
+                            "data": "Can Bounce in Ball"
                         }
                     }
                 },
@@ -6249,32 +6336,11 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
-                        "Door to Elevator to Restricted Zone": {
+                        "Top of Shaft": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "or",
-                                        "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can climb High Jump Wall"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "WallJump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
-                                        }
-                                    },
                                     {
                                         "type": "or",
                                         "data": {
@@ -6301,19 +6367,70 @@
                                                 {
                                                     "type": "resource",
                                                     "data": {
-                                                        "type": "damage",
-                                                        "name": "NormalDamage",
-                                                        "amount": 75,
+                                                        "type": "items",
+                                                        "name": "ScrewAttack",
+                                                        "amount": 1,
                                                         "negate": false
                                                     }
                                                 },
                                                 {
                                                     "type": "resource",
                                                     "data": {
+                                                        "type": "tricks",
+                                                        "name": "Combat",
+                                                        "amount": 2,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Freeze Enemies"
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "type": "or",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
                                                         "type": "items",
-                                                        "name": "ScrewAttack",
+                                                        "name": "SpaceJump",
                                                         "amount": 1,
                                                         "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "StandOnFrozenEnemies",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
                                                     }
                                                 }
                                             ]
@@ -6354,20 +6471,49 @@
                     "override_default_open_requirement": null,
                     "override_default_lock_requirement": null,
                     "connections": {
+                        "Top of Shaft": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can climb High Jump Wall"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "WallJump",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "Top of Shaft": {
+                    "node_type": "generic",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 150.0020387359837,
+                        "y": 313.7669045191981,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "connections": {
                         "Pickup (Hidden Energy Tank)": {
                             "type": "and",
                             "data": {
                                 "comment": null,
                                 "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "items",
-                                            "name": "MorphBall",
-                                            "amount": 1,
-                                            "negate": false
-                                        }
-                                    },
                                     {
                                         "type": "or",
                                         "data": {
@@ -6382,7 +6528,7 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "DiffusionMissiles",
+                                                                    "name": "Missiles",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -6391,7 +6537,7 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
-                                                                    "name": "Missiles",
+                                                                    "name": "DiffusionMissiles",
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
@@ -6402,20 +6548,20 @@
                                                 {
                                                     "type": "and",
                                                     "data": {
-                                                        "comment": "TODO: isnt this possible with SJ and maybe WJ too?",
+                                                        "comment": "Diagonal Missile shot at the third Missile Block when standing close to the wall can hit it (may not even have to freeze the enemy)",
                                                         "items": [
-                                                            {
-                                                                "type": "template",
-                                                                "data": "Can Freeze Enemies"
-                                                            },
                                                             {
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "items",
                                                                     "name": "Missiles",
-                                                                    "amount": 5,
+                                                                    "amount": 3,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Freeze Enemies"
                                                             },
                                                             {
                                                                 "type": "resource",
@@ -6425,11 +6571,29 @@
                                                                     "amount": 1,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Knowledge",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
                                                             }
                                                         ]
                                                     }
                                                 }
                                             ]
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "MorphBall",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
@@ -6438,74 +6602,56 @@
                         "Door to Ripper Maze Access": {
                             "type": "or",
                             "data": {
-                                "comment": "TODO: duplicated requirements, make a general node for top of left shaft. Also get proper damage values and fint hitless strat",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "or",
+                                        "type": "template",
+                                        "data": "Can Freeze Enemies"
+                                    },
+                                    {
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "template",
-                                                    "data": "Can climb High Jump Wall"
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "tricks",
-                                                        "name": "WallJump",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "tricks",
+                                            "name": "Combat",
+                                            "amount": 2,
+                                            "negate": false
                                         }
                                     },
                                     {
-                                        "type": "or",
+                                        "type": "resource",
                                         "data": {
-                                            "comment": null,
-                                            "items": [
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ChargeBeam",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "Missiles",
-                                                        "amount": 10,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "damage",
-                                                        "name": "NormalDamage",
-                                                        "amount": 75,
-                                                        "negate": false
-                                                    }
-                                                },
-                                                {
-                                                    "type": "resource",
-                                                    "data": {
-                                                        "type": "items",
-                                                        "name": "ScrewAttack",
-                                                        "amount": 1,
-                                                        "negate": false
-                                                    }
-                                                }
-                                            ]
+                                            "type": "items",
+                                            "name": "Missiles",
+                                            "amount": 10,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "ScrewAttack",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "ChargeBeam",
+                                            "amount": 1,
+                                            "negate": false
                                         }
                                     }
                                 ]
+                            }
+                        },
+                        "Door to Elevator to Restricted Zone": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
                             }
                         }
                     }
@@ -7140,11 +7286,27 @@
                                                 }
                                             ]
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "events",
+                                            "name": "S1ShotBlock",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
                         },
                         "Save Station": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Event - Shot Block": {
                             "type": "and",
                             "data": {
                                 "comment": null,
@@ -7184,24 +7346,12 @@
                     "override_default_lock_requirement": null,
                     "connections": {
                         "Door to Short Shaft": {
-                            "type": "or",
+                            "type": "resource",
                             "data": {
-                                "comment": null,
-                                "items": [
-                                    {
-                                        "type": "resource",
-                                        "data": {
-                                            "type": "misc",
-                                            "name": "EntranceRando",
-                                            "amount": 1,
-                                            "negate": true
-                                        }
-                                    },
-                                    {
-                                        "type": "template",
-                                        "data": "Can Use Any Bombs"
-                                    }
-                                ]
+                                "type": "events",
+                                "name": "S1ShotBlock",
+                                "amount": 1,
+                                "negate": false
                             }
                         }
                     }
@@ -7229,6 +7379,52 @@
                             "data": {
                                 "comment": null,
                                 "items": []
+                            }
+                        }
+                    }
+                },
+                "Event - Shot Block": {
+                    "node_type": "event",
+                    "heal": false,
+                    "coordinates": {
+                        "x": 247.29,
+                        "y": 87.6,
+                        "z": 0.0
+                    },
+                    "description": "",
+                    "layers": [
+                        "default"
+                    ],
+                    "extra": {},
+                    "valid_starting_location": false,
+                    "event_name": "S1ShotBlock",
+                    "connections": {
+                        "Door to Short Shaft": {
+                            "type": "and",
+                            "data": {
+                                "comment": null,
+                                "items": []
+                            }
+                        },
+                        "Other to Wall Jump Tutorial": {
+                            "type": "or",
+                            "data": {
+                                "comment": null,
+                                "items": [
+                                    {
+                                        "type": "template",
+                                        "data": "Can Bounce in Ball"
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "MidAirMorph",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -7337,12 +7533,46 @@
                                         }
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "ScrewAttack",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "ScrewAttack",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Screw Attack to defeat the Pirates can also (accidentally) destroy the platforms, unless cancelling spins",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "items",
+                                                                    "name": "SpaceJump",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Movement",
+                                                                    "amount": 1,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -7363,12 +7593,38 @@
                                         "data": "Can Use Power Bombs"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "damage",
-                                            "name": "NormalDamage",
-                                            "amount": 80,
-                                            "negate": false
+                                            "comment": "Shinespark from Atmospheric Stabilizer Room",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpeedBooster",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "DoorLockRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "misc",
+                                                        "name": "EntranceRando",
+                                                        "amount": 1,
+                                                        "negate": true
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -99,8 +99,9 @@ Extra - room_id: [3]
   * L0 Hatch to Entrance Hub/Door to Yameba Corridor
   * Extra - door_idx: (9,)
   > Door to Atmospheric Stabilizer Northwest
+      After Sector 1 Yameba Corridor Missile Geron
+  > Event - Missile Geron
       Any of the following:
-          # TODO: make this an event
           Can Kill Missile Geron
           Speed Booster and Knowledge (Beginner)
 
@@ -109,7 +110,17 @@ Extra - room_id: [3]
   * L0 Hatch to Atmospheric Stabilizer Northwest/Door to Yameba Corridor
   * Extra - door_idx: (10,)
   > Door to Entrance Hub
+      After Sector 1 Yameba Corridor Missile Geron
+  > Event - Missile Geron
       Can Kill Missile Geron
+
+> Event - Missile Geron; Heals? False
+  * Layers: default
+  * Event Sector 1 Yameba Corridor Missile Geron
+  > Door to Entrance Hub
+      Trivial
+  > Door to Atmospheric Stabilizer Northwest
+      Trivial
 
 ----------------
 Atmospheric Stabilizer Northwest
@@ -332,7 +343,9 @@ Extra - room_id: [10]
   > Door to Charge Core Arena
       Trivial
   > Other to Crab Rave
-      Missiles and Morph Ball
+      Morph Ball and After Sector 1 Charge Core Escape Missile Block
+  > Event - Missile Block
+      Missiles
 
 > Door to Charge Core Arena; Heals? False
   * Layers: default
@@ -346,7 +359,15 @@ Extra - room_id: [10]
   * Tunnel to Crab Rave/Other to Charge Core Escape
   * Extra - door_idx: (92,)
   > Door to Atmospheric Stabilizer Central
+      Morph Ball and After Sector 1 Charge Core Escape Missile Block
+
+> Event - Missile Block; Heals? False
+  * Layers: default
+  * Event Sector 1 Charge Core Escape Missile Block
+  > Door to Atmospheric Stabilizer Central
       Trivial
+  > Other to Crab Rave
+      Morph Ball
 
 ----------------
 Entrance Recharge Room
@@ -991,32 +1012,40 @@ Extra - room_id: [30]
   * Extra - room: 30
   * Extra - blockx: 15
   * Extra - blocky: 8
-  > Door to Elevator to Restricted Zone
-      Morph Ball and Can Bounce in Ball
+  > Top of Shaft
+      Can Bounce in Ball
 
 > Door to Ripper Maze Access; Heals? False
   * Layers: default
   * L0 Hatch to Ripper Maze Access/Door to Ripper Maze
   * Extra - door_idx: (62,)
-  > Door to Elevator to Restricted Zone
+  > Top of Shaft
       All of the following:
-          Wall Jump (Beginner) or Can climb High Jump Wall
-          Charge Beam or Missiles ≥ 10 or Screw Attack or Normal Damage ≥ 75
+          Charge Beam or Missiles ≥ 10 or Screw Attack or Combat (Intermediate) or Can Freeze Enemies
+          Any of the following:
+              Space Jump
+              Stand On Frozen Enemies (Beginner) and Wall Jump (Beginner) and Can Freeze Enemies
 
 > Door to Elevator to Restricted Zone; Heals? False
   * Layers: default
   * L0 Hatch to Elevator to Restricted Zone/Door to Ripper Maze
   * Extra - door_idx: (63,)
+  > Top of Shaft
+      Wall Jump (Beginner) or Can climb High Jump Wall
+
+> Top of Shaft; Heals? False
+  * Layers: default
   > Pickup (Hidden Energy Tank)
       All of the following:
           Morph Ball
           Any of the following:
               Diffusion Missiles and Missiles
-              # TODO: isnt this possible with SJ and maybe WJ too?
-              Missiles ≥ 5 and Stand On Frozen Enemies (Beginner) and Can Freeze Enemies
+              # Diagonal Missile shot at the third Missile Block when standing close to the wall can hit it (may not even have to freeze the enemy)
+              Missiles ≥ 3 and Knowledge (Beginner) and Stand On Frozen Enemies (Beginner) and Can Freeze Enemies
   > Door to Ripper Maze Access
-      # TODO: duplicated requirements, make a general node for top of left shaft. Also get proper damage values and fint hitless strat
-      Charge Beam or Missiles ≥ 10 or Screw Attack or Wall Jump (Beginner) or Normal Damage ≥ 75 or Can climb High Jump Wall
+      Charge Beam or Missiles ≥ 10 or Screw Attack or Combat (Intermediate) or Can Freeze Enemies
+  > Door to Elevator to Restricted Zone
+      Trivial
 
 ----------------
 Elevator to Restricted Zone
@@ -1122,9 +1151,11 @@ Extra - room_id: [34]
   * Extra - door_idx: (74,)
   > Other to Wall Jump Tutorial
       All of the following:
-          Morph Ball
+          Morph Ball and After Sector 1 Save Room East Shot Block
           Mid-Air Morph (Beginner) or Can Bounce in Ball
   > Save Station
+      Trivial
+  > Event - Shot Block
       Trivial
 
 > Other to Wall Jump Tutorial; Heals? False
@@ -1132,7 +1163,7 @@ Extra - room_id: [34]
   * Tunnel to Wall Jump Tutorial/Other to Save Room East
   * Extra - door_idx: (108,)
   > Door to Short Shaft
-      Disabled Entrance Rando or Can Use Any Bombs
+      After Sector 1 Save Room East Shot Block
 
 > Save Station; Heals? False; Spawn Point
   * Layers: default
@@ -1140,6 +1171,14 @@ Extra - room_id: [34]
   * Extra - Y: 10
   > Door to Short Shaft
       Trivial
+
+> Event - Shot Block; Heals? False
+  * Layers: default
+  * Event Sector 1 Save Room East Shot Block
+  > Door to Short Shaft
+      Trivial
+  > Other to Wall Jump Tutorial
+      Mid-Air Morph (Beginner) or Can Bounce in Ball
 
 ----------------
 South Shaft
@@ -1157,8 +1196,15 @@ Extra - room_id: [35]
   * L0 Hatch to Atmospheric Stabilizer Southeast/Door to South Shaft
   * Extra - door_idx: (73,)
   > Door to Short Shaft
-      # Deal with the Pirates
-      Charge Beam or Missiles ≥ 10 or Screw Attack or Combat (Intermediate) or Normal Damage ≥ 80 or Can Freeze Enemies or Can Use Power Bombs
+      Any of the following:
+          # Deal with the Pirates
+          Charge Beam or Missiles ≥ 10 or Combat (Intermediate) or Can Freeze Enemies or Can Use Power Bombs
+          All of the following:
+              Screw Attack
+              # Screw Attack to defeat the Pirates can also (accidentally) destroy the platforms, unless cancelling spins
+              Space Jump or Movement (Beginner)
+          # Shinespark from Atmospheric Stabilizer Room
+          Speed Booster and Disabled Door Lock Rando and Disabled Entrance Rando
 
 ----------------
 Tourian Entrance

--- a/randovania/games/fusion/logic_database/header.json
+++ b/randovania/games/fusion/logic_database/header.json
@@ -331,6 +331,18 @@
             "MainDeckPBGeron": {
                 "long_name": "Main Deck PB Geron",
                 "extra": {}
+            },
+            "S1MissileBlock": {
+                "long_name": "Sector 1 Charge Core Escape Missile Block",
+                "extra": {}
+            },
+            "S1MissileGeron": {
+                "long_name": "Sector 1 Yameba Corridor Missile Geron",
+                "extra": {}
+            },
+            "S1ShotBlock": {
+                "long_name": "Sector 1 Save Room East Shot Block",
+                "extra": {}
             }
         },
         "tricks": {


### PR DESCRIPTION
Per Miepee's list of todo items for sector 1

9: Added an event node for the missile block (for entrance rando)
14: Added a generic node for the top of the shaft to allow collecting the item from the left without dealing with the enemies
Bonus: Turns out diffusion is not required for that item :)
15: Added an event node for the shot block (though this block doesn't _actually_ block anything, as you spawn on top of it entering from the tunnel)
18: Added an event node for the missile Geron so that logic can leave after the first Stabilizer and Hornoad Hole item when routing a Speed Booster start.