### PR TITLE
S1: Add a couple extra tricks to the logic with video examples

### DIFF
--- a/randovania/games/fusion/logic_database/Sector 1 SRX.json
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.json
@@ -2788,6 +2788,23 @@
                                                                     "amount": 3,
                                                                     "negate": false
                                                                 }
+                                                            },
+                                                            {
+                                                                "type": "and",
+                                                                "data": {
+                                                                    "comment": "Possible without wall jumps or jump upgrades - https://youtu.be/WsY4pSmBAyo",
+                                                                    "items": [
+                                                                        {
+                                                                            "type": "resource",
+                                                                            "data": {
+                                                                                "type": "tricks",
+                                                                                "name": "ShinesparkTrick",
+                                                                                "amount": 4,
+                                                                                "negate": false
+                                                                            }
+                                                                        }
+                                                                    ]
+                                                                }
                                                             }
                                                         ]
                                                     }
@@ -2865,11 +2882,15 @@
                                                 {
                                                     "type": "or",
                                                     "data": {
-                                                        "comment": "Add SSWJ",
+                                                        "comment": null,
                                                         "items": [
                                                             {
                                                                 "type": "template",
                                                                 "data": "Can climb High Jump Wall"
+                                                            },
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
                                                             }
                                                         ]
                                                     }
@@ -5543,15 +5564,44 @@
                         "Door to Ridley Arena Access": {
                             "type": "and",
                             "data": {
-                                "comment": "Space Jump is required to leave because the exit creates an overhang",
+                                "comment": null,
                                 "items": [
                                     {
-                                        "type": "resource",
+                                        "type": "or",
                                         "data": {
-                                            "type": "items",
-                                            "name": "SpaceJump",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "and",
+                                                    "data": {
+                                                        "comment": "Can leave with single wall jumping, but currently this is never in logic - https://youtu.be/trYxYGq7PMs",
+                                                        "items": [
+                                                            {
+                                                                "type": "template",
+                                                                "data": "Can Screw Single Walljump"
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "WallJump",
+                                                                    "amount": 3,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "SpaceJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {

--- a/randovania/games/fusion/logic_database/Sector 1 SRX.txt
+++ b/randovania/games/fusion/logic_database/Sector 1 SRX.txt
@@ -484,13 +484,15 @@ Extra - room_id: [15]
           All of the following:
               # Shinespark from Screw Shaft - https://youtu.be/IP4zjb-1kP4
               Speed Booster and Knowledge (Beginner) and Shinespark Tricks (Advanced) and Disabled Door Lock Rando
-              Wall Jump (Advanced) or Can climb High Jump Wall
+              Any of the following:
+                  Wall Jump (Advanced) or Can climb High Jump Wall
+                  # Possible without wall jumps or jump upgrades - https://youtu.be/WsY4pSmBAyo
+                  Shinespark Tricks (Expert)
           # Farm X to kill with only 1 Missile
           Missiles and Combat (Beginner)
           All of the following:
               Screw Attack and Knowledge (Beginner)
-              # Add SSWJ
-              Can climb High Jump Wall
+              Can Single Walljump or Can climb High Jump Wall
 
 > Event - Stabilizer 4 Online; Heals? False
   * Layers: default
@@ -912,8 +914,12 @@ Extra - room_id: [27]
 > Arena; Heals? False
   * Layers: default
   > Door to Ridley Arena Access
-      # Space Jump is required to leave because the exit creates an overhang
-      Space Jump and After Neo-Ridley
+      All of the following:
+          After Neo-Ridley
+          Any of the following:
+              Space Jump
+              # Can leave with single wall jumping, but currently this is never in logic - https://youtu.be/trYxYGq7PMs
+              Wall Jump (Advanced) and Can Single Walljump
   > Event - Neo-Ridley
       All of the following:
           Any of the following:


### PR DESCRIPTION
Clue showed that wall jump/high jump/space jump are not needed for Southeast Stabilizer Shinespark trick

Also, ledge grabbing the exit of Ridley's Arena is possible if you single wall jump up the right side
(Single wall jumping isn't in logic yet, so this won't be used, but laid the ground work for this anyway)

(I was able to also use these videos and methods myself to do the tricks, to assign the proper difficulty levels)