### PR TITLE
Expected dmg (Main Deck and S2)

### DIFF
--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -7707,7 +7707,7 @@
                                                     "type": "resource",
                                                     "data": {
                                                         "type": "tricks",
-                                                        "name": "Knowledge",
+                                                        "name": "Combat",
                                                         "amount": 1,
                                                         "negate": false
                                                     }

--- a/randovania/games/fusion/logic_database/Main Deck.json
+++ b/randovania/games/fusion/logic_database/Main Deck.json
@@ -7604,8 +7604,42 @@
                                 "comment": null,
                                 "items": [
                                     {
-                                        "type": "template",
-                                        "data": "Can Kill Tough Beam-Resistant Enemy"
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Kill Tough Beam-Resistant Enemy"
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": "Expected dmg trickless",
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "NormalDamage",
+                                                                    "amount": 128,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
                                         "type": "and",
@@ -7640,6 +7674,45 @@
                                             "name": "Combat",
                                             "amount": 3,
                                             "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "items",
+                                            "name": "ScrewAttack",
+                                            "amount": 1,
+                                            "negate": false
+                                        }
+                                    },
+                                    {
+                                        "type": "and",
+                                        "data": {
+                                            "comment": null,
+                                            "items": [
+                                                {
+                                                    "type": "template",
+                                                    "data": "Can Use Power Bombs"
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "PowerBombs",
+                                                        "amount": 4,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "tricks",
+                                                        "name": "Knowledge",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                }
+                                            ]
                                         }
                                     }
                                 ]

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1350,7 +1350,7 @@ Extra - room_id: [51]
               # Expected dmg trickless
               Combat (Intermediate) or Normal Damage ≥ 128
           Damage Boosts (Intermediate) and Normal Damage ≥ 195
-          Power Bombs ≥ 4 and Knowledge (Beginner) and Can Use Power Bombs
+          Power Bombs ≥ 4 and Combat (Beginner) and Can Use Power Bombs
 
 > Door to Yakuza Arena; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Main Deck.txt
+++ b/randovania/games/fusion/logic_database/Main Deck.txt
@@ -1344,8 +1344,13 @@ Extra - room_id: [51]
   * Extra - door_idx: (116,)
   > Beside Pickup
       Any of the following:
-          Combat (Advanced) or Can Kill Tough Beam-Resistant Enemy
+          Screw Attack or Combat (Advanced)
+          All of the following:
+              Can Kill Tough Beam-Resistant Enemy
+              # Expected dmg trickless
+              Combat (Intermediate) or Normal Damage ≥ 128
           Damage Boosts (Intermediate) and Normal Damage ≥ 195
+          Power Bombs ≥ 4 and Knowledge (Beginner) and Can Use Power Bombs
 
 > Door to Yakuza Arena; Heals? False
   * Layers: default

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -6186,6 +6186,15 @@
                                             "amount": 1,
                                             "negate": false
                                         }
+                                    },
+                                    {
+                                        "type": "resource",
+                                        "data": {
+                                            "type": "tricks",
+                                            "name": "Knowledge",
+                                            "amount": 3,
+                                            "negate": false
+                                        }
                                     }
                                 ]
                             }
@@ -6722,12 +6731,46 @@
                                         "data": "Can Freeze Enemies"
                                     },
                                     {
-                                        "type": "resource",
+                                        "type": "and",
                                         "data": {
-                                            "type": "items",
-                                            "name": "HighJump",
-                                            "amount": 1,
-                                            "negate": false
+                                            "comment": "dmg expectations",
+                                            "items": [
+                                                {
+                                                    "type": "resource",
+                                                    "data": {
+                                                        "type": "items",
+                                                        "name": "HighJump",
+                                                        "amount": 1,
+                                                        "negate": false
+                                                    }
+                                                },
+                                                {
+                                                    "type": "or",
+                                                    "data": {
+                                                        "comment": null,
+                                                        "items": [
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "damage",
+                                                                    "name": "NormalDamage",
+                                                                    "amount": 34,
+                                                                    "negate": false
+                                                                }
+                                                            },
+                                                            {
+                                                                "type": "resource",
+                                                                "data": {
+                                                                    "type": "tricks",
+                                                                    "name": "Combat",
+                                                                    "amount": 2,
+                                                                    "negate": false
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         }
                                     },
                                     {
@@ -6767,7 +6810,7 @@
                                                     "data": {
                                                         "type": "damage",
                                                         "name": "NormalDamage",
-                                                        "amount": 35,
+                                                        "amount": 34,
                                                         "negate": false
                                                     }
                                                 }
@@ -6915,9 +6958,9 @@
                                     {
                                         "type": "resource",
                                         "data": {
-                                            "type": "items",
-                                            "name": "HighJump",
-                                            "amount": 1,
+                                            "type": "damage",
+                                            "name": "NormalDamage",
+                                            "amount": 34,
                                             "negate": false
                                         }
                                     },
@@ -6934,8 +6977,8 @@
                                         "type": "resource",
                                         "data": {
                                             "type": "tricks",
-                                            "name": "Movement",
-                                            "amount": 3,
+                                            "name": "Combat",
+                                            "amount": 2,
                                             "negate": false
                                         }
                                     },

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.json
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.json
@@ -6762,7 +6762,7 @@
                                                                 "type": "resource",
                                                                 "data": {
                                                                     "type": "tricks",
-                                                                    "name": "Combat",
+                                                                    "name": "Movement",
                                                                     "amount": 2,
                                                                     "negate": false
                                                                 }

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1108,7 +1108,7 @@ Extra - room_id: [33]
           All of the following:
               # dmg expectations
               High Jump
-              Combat (Intermediate) or Normal Damage ≥ 34
+              Movement (Intermediate) or Normal Damage ≥ 34
           # Kago Jump
           Damage Boosts (Expert) and Wall Jump (Expert) and Normal Damage ≥ 34
           # Shinespark from entrance rooms

--- a/randovania/games/fusion/logic_database/Sector 2 TRO.txt
+++ b/randovania/games/fusion/logic_database/Sector 2 TRO.txt
@@ -1027,7 +1027,7 @@ Extra - room_id: [32, 35]
   > Door to Owtch Cache B
       Trivial
   > Other to Hidden Recharge Room
-      Morph Ball
+      Morph Ball and Knowledge (Advanced)
   > Door to Nettori Save Room
       Can Kill Tough Beam-Weak Enemy
 
@@ -1104,9 +1104,13 @@ Extra - room_id: [33]
   * Extra - door_idx: (73,)
   > Beside missile tank
       Any of the following:
-          High Jump or Screw Attack or Space Jump or Can Freeze Enemies
+          Screw Attack or Space Jump or Can Freeze Enemies
+          All of the following:
+              # dmg expectations
+              High Jump
+              Combat (Intermediate) or Normal Damage ≥ 34
           # Kago Jump
-          Damage Boosts (Expert) and Wall Jump (Expert) and Normal Damage ≥ 35
+          Damage Boosts (Expert) and Wall Jump (Expert) and Normal Damage ≥ 34
           # Shinespark from entrance rooms
           Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
 
@@ -1123,7 +1127,7 @@ Extra - room_id: [33]
       Trivial
   > Door to Entrance Hub
       Any of the following:
-          High Jump or Screw Attack or Space Jump or Movement (Advanced) or Can Freeze Enemies
+          Screw Attack or Space Jump or Combat (Intermediate) or Normal Damage ≥ 34 or Can Freeze Enemies
           # Assumes you shinesparked in and killed the Kago
           Speed Booster and Shinespark Tricks (Beginner) and Disabled Door Lock Rando and Disabled Entrance Rando
   > Door to Connection to Sector 1 (SRX)


### PR DESCRIPTION
-Kago Room requires etank for beginners
-Silo Scaffolding B requires etank even if you can kill pirates for beginners
-Fixed logic on Nettori recharge room